### PR TITLE
Small environmental variable changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-APP_TOKEN_KEY=
+RCTF_TOKEN_KEY=LMyfS/PlmrRQNVQMPPT1acfJf+XWh4JRPH6VX+9vNVY=
 RCTF_DATABASE_URL=postgresql://user:password@database.server:5432/rctf

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You should copy the `.env.example` to `.env`.
 ~/rctf $ cp .env.example .env
 ```
 
-Note that the `APP_TOKEN_KEY` should be a base64 encoded string of length 32 bytes. You can generate one with the following command.  
+Note that the `RCTF_TOKEN_KEY` should be a base64 encoded string of length 32 bytes. You can generate one with the following command.  
 
 ```
 $ openssl rand -base64 32

--- a/config/index.js
+++ b/config/index.js
@@ -1,3 +1,4 @@
 module.exports = {
-  rDeployDirectory: '.rdeploy'
+  rDeployDirectory: '.rdeploy',
+  tokenKey: process.env.RCTF_TOKEN_KEY
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "standard",
     "start": "node index.js",
-    "migrate": "node-pg-migrate",
+    "migrate": "node-pg-migrate --database-url-var=RCTF_DATABASE_URL",
     "build": "sh client/build.sh",
     "watch": "preact watch --src client/src --template client/index.html",
     "dev": "nodemon index.js",

--- a/server/auth/token.js
+++ b/server/auth/token.js
@@ -1,8 +1,9 @@
 const { promisify } = require('util')
 const crypto = require('crypto')
 
+const config = require('../../config')
 const randomBytes = promisify(crypto.randomBytes)
-const tokenKey = Buffer.from(process.env.APP_TOKEN_KEY, 'base64')
+const tokenKey = Buffer.from(config.tokenKey, 'base64')
 
 const tokenKinds = {
   auth: 0


### PR DESCRIPTION
Two small quality of life updates. 
1. Configure `yarn migrate` to use `RCTF_DATABASE_URL`
2. Switch `APP_TOKEN_KEY` to `RCTF_TOKEN_KEY` as per @ginkoid naming conventions. Also moved token key to config to be more declarative