### PR TITLE
Added flag for compression

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ const { enableCORS, serveDownloads } = require('./server/util')
 require('./server/leaderboard').startUpdater()
 
 const app = express()
-if (process.env.TEST_COMPRESSION !== undefined) {
+if (process.env.NODE_ENV !== 'production' && process.env.TEST_COMPRESSION !== undefined) {
   const compression = require('compression')
   app.use(compression({
     level: 9,

--- a/app.js
+++ b/app.js
@@ -5,6 +5,13 @@ const { enableCORS, serveDownloads } = require('./server/util')
 require('./server/leaderboard').startUpdater()
 
 const app = express()
+if (process.env.TEST_COMPRESSION !== undefined) {
+  const compression = require('compression')
+  app.use(compression({
+    level: 9,
+    filter: () => true
+  }))
+}
 
 app.use(enableCORS)
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ava": "^3.3.0",
     "babel-eslint": "^10.0.3",
     "cirrus-ui": "^0.5.5",
+    "compression": "^1.7.4",
     "dotenv": "^8.2.0",
     "glob": "^7.1.6",
     "husky": "^4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2305,7 +2305,7 @@ compressible@~2.0.16:
   dependencies:
     mime-db ">= 1.43.0 < 2"
 
-compression@^1.7.3:
+compression@^1.7.3, compression@^1.7.4:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.4.tgz#95523eff170ca57c29a0ca41e6fe131f41e5bb8f"
   integrity sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==


### PR DESCRIPTION
Simple quality of life PR, use `TEST_COMPRESSION=1 yarn dev` to run with compression to see true bundle sizes. 