### PR TITLE
Fix environment variables not being set correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ jobs:
         - redis-server
 
       env:
-        global:
         - RCTF_DATABASE_URL=postgres://postgres@localhost/rctf
         - RCTF_REDIS_URL=redis://@localhost:6379/0
 


### PR DESCRIPTION
Environment variables were mistakenly being set under the "global" key in "env"; fix this and remove the extraneous key