### PR TITLE
Use factored import for uuid over deprecated import syntax

### DIFF
--- a/server/api/auth/recover.js
+++ b/server/api/auth/recover.js
@@ -1,4 +1,4 @@
-const uuidv4 = require('uuid/v4')
+const { v4: uuidv4 } = require('uuid')
 const emailValidator = require('email-validator')
 const cache = require('../../cache')
 const util = require('../../util')

--- a/server/api/auth/register.js
+++ b/server/api/auth/register.js
@@ -1,4 +1,4 @@
-const uuidv4 = require('uuid/v4')
+const { v4: uuidv4 } = require('uuid')
 const emailValidator = require('email-validator')
 const cache = require('../../cache')
 const util = require('../../util')

--- a/server/api/submitflag.js
+++ b/server/api/submitflag.js
@@ -4,7 +4,7 @@ const { responses } = require('../responses')
 const config = require('../../config/server')
 const util = require('../util')
 
-const uuidv4 = require('uuid/v4')
+const { v4: uuidv4 } = require('uuid')
 
 module.exports = {
   method: 'post',

--- a/server/auth/register.js
+++ b/server/auth/register.js
@@ -1,4 +1,4 @@
-const uuidv4 = require('uuid/v4')
+const { v4: uuidv4 } = require('uuid')
 const database = require('../database')
 const tokenUtils = require('./token')
 const { responses } = require('../responses')

--- a/test/_util.js
+++ b/test/_util.js
@@ -1,6 +1,6 @@
 require('ava')
 
-const uuidv4 = require('uuid/v4')
+const { v4: uuidv4 } = require('uuid')
 const config = require('../config/server')
 
 module.exports = {

--- a/test/integration/challenges.js
+++ b/test/integration/challenges.js
@@ -1,7 +1,7 @@
 const test = require('ava')
 const request = require('supertest')
 const app = require('../../app')
-const uuidv4 = require('uuid/v4')
+const { v4: uuidv4 } = require('uuid')
 const auth = require('../../server/auth')
 const config = require('../../config/server')
 

--- a/test/integration/profile.js
+++ b/test/integration/profile.js
@@ -1,7 +1,7 @@
 const test = require('ava')
 const request = require('supertest')
 const app = require('../../app')
-const uuidv4 = require('uuid/v4')
+const { v4: uuidv4 } = require('uuid')
 
 const config = require('../../config/server')
 const { removeUserByEmail } = require('../../server/database').auth

--- a/test/integration/submit.js
+++ b/test/integration/submit.js
@@ -1,7 +1,7 @@
 const test = require('ava')
 const request = require('supertest')
 const app = require('../../app')
-const uuidv4 = require('uuid/v4')
+const { v4: uuidv4 } = require('uuid')
 
 const db = require('../../server/database')
 const challenges = require('../../server/challenges')

--- a/test/integration/submitTiming.js
+++ b/test/integration/submitTiming.js
@@ -2,7 +2,7 @@ const test = require('ava')
 const request = require('supertest')
 const app = require('../../app')
 const config = require('../../config/server')
-const uuidv4 = require('uuid/v4')
+const { v4: uuidv4 } = require('uuid')
 
 const challenges = require('../../server/challenges')
 const { responseList } = require('../../server/responses')


### PR DESCRIPTION
We updated to uuid@7, which deprecated the deep import syntax. Switch all imports to use the new factored import syntax.