### PR TITLE
Whitelist files to include in coverage instead of blacklisting

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,4 +1,4 @@
 {
   "all": true,
-  "exclude": ["migrations", "test", ".rdeploy", "client", "build", "preact.config.js", "**/.eslintrc.js", "coverage"]
+  "include": ["server/**", "index.js", "app.js"]
 }


### PR DESCRIPTION
Switch nyc config to explicitly include files to include in coverage, instead of excluding most of the repository