### PR TITLE
Refactor eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,18 @@
+module.exports = {
+  env: {
+    es6: true
+  },
+  extends: [
+    'standard'
+  ],
+  parserOptions: {
+    ecmaFeatures: {
+    },
+    ecmaVersion: 2018,
+    sourceType: 'module'
+  },
+  plugins: [
+  ],
+  rules: {
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "lint": "tsc --noEmit && eslint --ext .js,.ts client server",
+    "lint": "tsc --noEmit && eslint --ext .js,.ts .",
     "start": "node dist/server/index.js",
     "migrate": "node-pg-migrate --database-url-var=RCTF_DATABASE_URL",
     "build:client": "sh client/build.sh",

--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -1,22 +1,5 @@
 module.exports = {
   parser:  '@typescript-eslint/parser',
-  env: {
-    es6: true
-  },
-  extends: [
-    'standard',
-    'plugin:ava/recommended'
-  ],
-  globals: {
-    Atomics: 'readonly',
-    SharedArrayBuffer: 'readonly'
-  },
-  parserOptions: {
-    ecmaFeatures: {
-    },
-    ecmaVersion: 2018,
-    sourceType: 'module'
-  },
   plugins: [
     "typescript"
   ],

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  extends: [
+    'plugin:ava/recommended'
+  ],
+  plugins: [
+  ],
+  rules: {
+  }
+}


### PR DESCRIPTION
Add back root eslintrc enforcing standard style and other project-wide options, make server/ eslintrc add typescript plugins only, and move ava plugin to test/.eslintrc.js

Also drop unused global definitions