### PR TITLE
Allow querystring parameters as an object in request

### DIFF
--- a/client/src/api/scoreboard.js
+++ b/client/src/api/scoreboard.js
@@ -1,6 +1,14 @@
 import { request } from './util'
 
-export const getScoreboard = (limit = 100, offset = 0) => {
-  return request('GET', `/leaderboard?limit=${encodeURIComponent(limit)}&offset=${encodeURIComponent(offset)}`)
+export const getScoreboard = ({
+  division,
+  limit,
+  offset
+}) => {
+  limit = limit || 100
+  offset = offset || 0
+  return request('GET', '/leaderboard', {
+    division, limit, offset
+  })
     .then(resp => resp.data)
 }

--- a/client/src/api/util.js
+++ b/client/src/api/util.js
@@ -11,14 +11,15 @@ export const request = (method, endpoint, data) => {
   let qs = ''
   if (method === 'GET' && data) {
     // encode data into the querystring
-    qs = Object.keys(data)
+    // eslint-disable-next-line prefer-template
+    qs = '?' + Object.keys(data)
       .filter(k => data[k] !== undefined)
       .map(k => `${k}=${encodeURIComponent(data[k])}`)
       .join('&')
   } else {
     body = data
   }
-  return fetch(`${config.apiEndpoint}${endpoint}?${qs}`, {
+  return fetch(config.apiEndpoint + endpoint + qs, {
     method,
     headers: {
       'Content-Type': 'application/json',

--- a/client/src/api/util.js
+++ b/client/src/api/util.js
@@ -7,13 +7,24 @@ export const relog = () => {
 }
 
 export const request = (method, endpoint, data) => {
-  return fetch(config.apiEndpoint + endpoint, {
+  let body = null
+  let qs = ''
+  if (method === 'GET' && data) {
+    // encode data into the querystring
+    qs = Object.keys(data)
+      .filter(k => data[k] !== undefined)
+      .map(k => `${k}=${encodeURIComponent(data[k])}`)
+      .join('&')
+  } else {
+    body = data
+  }
+  return fetch(`${config.apiEndpoint}${endpoint}?${qs}`, {
     method,
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${localStorage.getItem('token')}`
     },
-    body: JSON.stringify(data)
+    body: body && JSON.stringify(body)
   })
     .then(resp => resp.json())
     .then(resp => {


### PR DESCRIPTION
Refactor `request()` to automatically put the contents of `data` into the querystring of a request if the request method is `GET`. This implementation currently will add extraneous `?`s to the request URL
when no querystring parameters are provided, however it appears that it is stripped off by the browser.