### PR TITLE
Fix ESLint TypeScript configs and exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "uuid": "^7.0.2"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^2.24.0",
     "@typescript-eslint/parser": "^2.24.0",
     "ava": "^3.3.0",
     "babel-eslint": "^10.0.3",
@@ -54,7 +55,6 @@
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
-    "eslint-plugin-typescript": "^0.14.0",
     "faker": "^4.1.0",
     "get-port": "^5.1.1",
     "glob": "^7.1.6",

--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -1,8 +1,20 @@
 module.exports = {
-  parser:  '@typescript-eslint/parser',
+  env: {
+    node: true
+  },
   plugins: [
-    "typescript"
   ],
   rules: {
-  }
+  },
+  overrides: [{
+    files: ['*.ts'],
+    parser: '@typescript-eslint/parser',
+    extends: [
+      'plugin:@typescript-eslint/eslint-recommended',
+      'plugin:@typescript-eslint/recommended',
+    ],
+    plugins: [
+      '@typescript-eslint'
+    ]
+  }]
 }

--- a/server/util/normalize.ts
+++ b/server/util/normalize.ts
@@ -1,5 +1,5 @@
-const path = require('path')
-const config = require('../../config/server')
+import path from 'path'
+import config from '../../config/server'
 
 const normalizeEmail = (email: string): string => {
   return email.trim().toLowerCase()

--- a/server/util/normalize.ts
+++ b/server/util/normalize.ts
@@ -1,15 +1,15 @@
 import path from 'path'
 import config from '../../config/server'
 
-const normalizeEmail = (email: string): string => {
+export function normalizeEmail (email: string): string {
   return email.trim().toLowerCase()
 }
 
-const normalizeName = (name: string): string => {
+export function normalizeName (name: string): string {
   return name.trim().toLowerCase()
 }
 
-const normalizeDownload = (name: string): string => {
+export function normalizeDownload (name: string): string {
   const filename = path.basename(name)
 
   const parts = filename.split('.')
@@ -24,10 +24,4 @@ const normalizeDownload = (name: string): string => {
   const cleanName = parts.join('.')
 
   return cleanName
-}
-
-module.exports = {
-  normalizeEmail,
-  normalizeName,
-  normalizeDownload
 }

--- a/server/util/scores.ts
+++ b/server/util/scores.ts
@@ -1,7 +1,7 @@
 const threshold = 100
 
 module.exports = {
-  getScore: (type:string, minVal:number, maxVal:number, solves:number):number => {
+  getScore: (type: string, minVal: number, maxVal: number, solves: number): number => {
     if (type === 'static') {
       return minVal
     } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -474,6 +474,17 @@
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.0.32.tgz#0d3cb31022f8427ea58c008af32b80da126ca4e3"
   integrity sha1-DTyzECL4Qn6ljACK8yuA2hJspOM=
 
+"@typescript-eslint/eslint-plugin@^2.24.0":
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.24.0.tgz#a86cf618c965a462cddf3601f594544b134d6d68"
+  integrity sha512-wJRBeaMeT7RLQ27UQkDFOu25MqFOBus8PtOa9KaT5ZuxC1kAsd7JEHqWt4YXuY9eancX0GK9C68i5OROnlIzBA==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "2.24.0"
+    eslint-utils "^1.4.3"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^3.0.0"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/experimental-utils@2.24.0", "@typescript-eslint/experimental-utils@^2.5.0":
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.24.0.tgz#a5cb2ed89fedf8b59638dc83484eb0c8c35e1143"
@@ -4063,13 +4074,6 @@ eslint-plugin-standard@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz#ff0519f7ffaff114f76d1bd7c3996eef0f6e20b4"
   integrity sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==
-
-eslint-plugin-typescript@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-typescript/-/eslint-plugin-typescript-0.14.0.tgz#068549c3f4c7f3f85d88d398c29fa96bf500884c"
-  integrity sha512-2u1WnnDF2mkWWgU1lFQ2RjypUlmRoBEvQN02y9u+IL12mjWlkKFGEBnVsjs9Y8190bfPQCvWly1c2rYYUSOxWw==
-  dependencies:
-    requireindex "~1.1.0"
 
 eslint-scope@^5.0.0:
   version "5.0.0"
@@ -9282,11 +9286,6 @@ require-relative@^0.8.7:
   version "0.8.7"
   resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
   integrity sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=
-
-requireindex@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
-  integrity sha1-5UBLgVV+91225JxacgBIk/4D4WI=
 
 requires-port@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
ESLint server config was previously not using typescript rules for typescript, fix config to enable typescript rules for typescript files only, and enforce rules.

Also fix server/util/normlalize.ts not exporting its methods via ES6 exports, which causes tsc to not recognize its exports.