### PR TITLE
Ensure standard rules are enforced

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -3,7 +3,11 @@ module.exports = {
     browser: true
   },
   extends: [
-    'preact'
+    'preact',
+
+    // include standard again since preact sets style options which override
+    // those of standard (see preactjs/eslint-config-preact#6)
+    'standard'
   ],
   plugins: [
   ],

--- a/client/src/api/auth.js
+++ b/client/src/api/auth.js
@@ -23,8 +23,8 @@ export const login = ({ teamToken }) => {
 }
 
 export const logout = () => {
-  localStorage.removeItem("token")
-  localStorage.removeItem("teamToken")
+  localStorage.removeItem('token')
+  localStorage.removeItem('teamToken')
 
   return route('/')
 }

--- a/client/src/pages/challenges.js
+++ b/client/src/pages/challenges.js
@@ -191,7 +191,7 @@ export default withStyles({
                   const clickHander = useCallback(
                     () => this.handleInvertCategoryState(category),
                     [category]
-                  );
+                  )
                   return (
                     <div key={category} class='form-ext-control form-ext-checkbox'>
                       <input id={category} class='form-ext-input' type='checkbox' checked={categories[category]} onClick={clickHander} />

--- a/client/src/pages/logout.js
+++ b/client/src/pages/logout.js
@@ -1,5 +1,5 @@
 import { useLayoutEffect } from 'preact/hooks'
-import {logout} from '../api/auth'
+import { logout } from '../api/auth'
 import 'linkstate/polyfill'
 
 export default () => {

--- a/client/src/pages/profile.js
+++ b/client/src/pages/profile.js
@@ -80,7 +80,7 @@ export default withStyles({
     return uuid === undefined || uuid === 'me'
   }
 
-  static getDerivedStateFromProps(props, state) {
+  static getDerivedStateFromProps (props, state) {
     if (props.uuid !== state.uuid) {
       return {
         uuid: props.uuid,
@@ -93,7 +93,7 @@ export default withStyles({
 
   componentDidUpdate () {
     if (!this.state.loaded) {
-      const { uuid } = this.state;
+      const { uuid } = this.state
 
       if (this.isPrivate()) {
         privateProfile()


### PR DESCRIPTION
The eslint preact config currently overrides style rules (see preactjs/eslint-config-preact#6), so override that by loading the standard config again.