### PR TITLE
Defer attempt to scroll to own team on scoreboard until the user's team's scoreboard page is loaded

### DIFF
--- a/client/src/pages/scoreboard.js
+++ b/client/src/pages/scoreboard.js
@@ -69,6 +69,21 @@ const Scoreboard = withStyles({
   }, [division, page, pageSize])
 
   const isUserOnCurrentScoreboard = loggedIn && (division === '' || Number.parseInt(division) === profile.division)
+  const isSelfVisible = useMemo(() => {
+    if (profile == null) return false
+    let isSelfVisible = false
+    // TODO: maybe avoiding iterating over scores again?
+    scores.forEach(({ id }) => {
+      if (id === profile.id) {
+        isSelfVisible = true
+      }
+    })
+    return isSelfVisible
+  }, [profile, scores])
+  const scrollToSelf = useCallback(() => {
+    selfRow.current.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+  }, [selfRow])
+  const [needsScrollToSelf, setNeedsScrollToSelf] = useState(false)
   const goToSelfPage = useCallback(() => {
     if (!isUserOnCurrentScoreboard) return
     let place
@@ -79,8 +94,20 @@ const Scoreboard = withStyles({
     }
     setPage(Math.floor((place - 1) / pageSize) + 1)
 
-    selfRow.current.scrollIntoView({ block: 'end', behavior: 'smooth' })
-  }, [profile, setPage, pageSize, division, isUserOnCurrentScoreboard])
+    if (isSelfVisible) {
+      scrollToSelf()
+    } else {
+      setNeedsScrollToSelf(true)
+    }
+  }, [profile, setPage, pageSize, division, isUserOnCurrentScoreboard, isSelfVisible, scrollToSelf])
+  useEffect(() => {
+    if (needsScrollToSelf) {
+      if (isSelfVisible) {
+        scrollToSelf()
+        setNeedsScrollToSelf(false)
+      }
+    }
+  }, [isSelfVisible, needsScrollToSelf, scrollToSelf])
 
   return (
     <div class='row u-center' style='align-items: initial !important'>

--- a/client/src/pages/scoreboard.js
+++ b/client/src/pages/scoreboard.js
@@ -125,11 +125,11 @@ const Scoreboard = withStyles({
                 </tr>
               </thead>
               <tbody>
-                {
-                  scores.map(({ id, name, score, rank }) => {
-                    const isSelf = profile != null && profile.id === id
+                { scores.map(({ id, name, score, rank }) => {
+                  const isSelf = profile != null && profile.id === id
 
-                    return <tr key={id}
+                  return (
+                    <tr key={id}
                       class={isSelf ? classes.selected : ''}
                       ref={isSelf && selfRow}
                     >
@@ -139,18 +139,14 @@ const Scoreboard = withStyles({
                       </td>
                       <td>{score}</td>
                     </tr>
-                  })
-
-                }
+                  )
+                }) }
               </tbody>
             </table>
           </div>
           { totalItems > pageSize &&
             <Pagination
-              totalItems={totalItems}
-              pageSize={pageSize}
-              page={page}
-              setPage={setPage}
+              {...{ totalItems, pageSize, page, setPage }}
               numVisiblePages={9}
             />
           }


### PR DESCRIPTION
If the user's team is not on the current scoreboard page, defer the attempt to scroll it into view until the data for the scoreboard page the user is on is actually loaded.

A possible optimization for this is to scroll to the element where the user's team "would" be located on the scoreboard before the data has loaded, however that would require us to reuse the host elements in the table when the scoreboard page changes.

Fixes #119 