### PR TITLE
Add modal for confirming account deletion

### DIFF
--- a/client/src/components/modal.js
+++ b/client/src/components/modal.js
@@ -19,6 +19,18 @@ function Modal ({
     }
   }, [open])
 
+  useEffect(() => {
+    function listener (e) {
+      if (e.key === 'Escape') {
+        onClose()
+      }
+    }
+    if (open) {
+      document.addEventListener('keyup', listener)
+      return () => document.removeEventListener('keyup', listener)
+    }
+  }, [open, onClose])
+
   // For some reason unmounting portals causes Preact to crash, so just don't
   // render the modal in a portal as Cirrus already applies styles to make the
   // modal appear over everything from anywhere in the tree.

--- a/client/src/components/modal.js
+++ b/client/src/components/modal.js
@@ -1,0 +1,70 @@
+import { useState, useEffect } from 'preact/hooks'
+import withStyles from './jss'
+
+const ANIMATION_DURATION = 150
+
+function Modal ({
+  classes, open, onClose, children
+}) {
+  const [isLinger, setIsLinger] = useState(open)
+
+  useEffect(() => {
+    if (open) {
+      setIsLinger(true)
+    } else {
+      const timer = setTimeout(() => {
+        setIsLinger(false)
+      }, ANIMATION_DURATION)
+      return () => clearTimeout(timer)
+    }
+  }, [open])
+
+  // For some reason unmounting portals causes Preact to crash, so just don't
+  // render the modal in a portal as Cirrus already applies styles to make the
+  // modal appear over everything from anywhere in the tree.
+  return (open || isLinger) &&
+    <div class={`modal shown ${classes.animated}${open ? '' : ' leaving'}`} hidden={!(open || isLinger)}>
+      <div class='modal-overlay' onClick={onClose} aria-label='Close' />
+      <div class='modal-content' role='document'>
+        {children}
+      </div>
+    </div>
+}
+
+const ANIMATION_INITIAL_SCALE = 0.8
+
+export default withStyles({
+  '@keyframes container': {
+    from: {
+      opacity: 0
+    },
+    to: {
+      opactiy: 1
+    }
+  },
+  '@keyframes content': {
+    from: {
+      transform: `scale(${ANIMATION_INITIAL_SCALE})`
+    },
+    to: {
+      transform: 'scale(1)'
+    }
+  },
+  animated: {
+    '&': {
+      display: 'flex',
+      animation: `$container ${ANIMATION_DURATION}ms ease-out`
+    },
+    '& .modal-content': {
+      animation: `$content ${ANIMATION_DURATION}ms ease-out`
+    },
+    '&.leaving': {
+      opacity: 0,
+      transition: `opacity ${ANIMATION_DURATION}ms ease-in`
+    },
+    '&.leaving .modal-content': {
+      transform: `scale(${ANIMATION_INITIAL_SCALE})`,
+      transition: `transform ${ANIMATION_DURATION}ms ease-in`
+    }
+  }
+}, Modal)


### PR DESCRIPTION
Add modal component using Cirrus's modals (with manual animations, since Cirrus relies on using the URI hash to show/hide modals), and use it to implement confirmation for deleting accounts instead of `prompt()`

![the modal](https://user-images.githubusercontent.com/5903672/77484583-4a5f3e80-6e01-11ea-9760-08beddac1ed3.png)

Closes #74