### PR TITLE
Restyle account deletion dialog

### DIFF
--- a/client/src/pages/profile.js
+++ b/client/src/pages/profile.js
@@ -20,6 +20,9 @@ for (const division of Object.entries(config.divisions)) {
 }
 
 const DeleteModal = withStyles({
+  modalBody: {
+    paddingTop: '0em !important' // reduce space between header and body
+  },
   controls: {
     display: 'flex',
     justifyContent: 'center',
@@ -55,22 +58,23 @@ const DeleteModal = withStyles({
     <Modal {...{ open, onClose }}>
       <div class='modal-header'>
         <div class='modal-title'>Delete account</div>
-        <form class='modal-body' onSubmit={verifyName}>
-          <p>Are you sure you want to delete your team?</p>
-          <div class='form-section'>
-            <label>Type your team name:</label>
-            <input placeholder={teamName} value={inputName} onChange={handleInputNameChange} />
-          </div>
-          <div class={`form-section ${classes.controls}`}>
-            <div class='btn-container u-inline-block'>
-              <button class='btn-small' onClick={wrappedOnClose}>Cancel</button>
-            </div>
-            <div class='btn-container u-inline-block'>
-              <input type='submit' class='btn-small btn-danger outline' disabled={!isNameValid} value='Confirm' />
-            </div>
-          </div>
-        </form>
       </div>
+      {/* Put buttons in the body because otherwise there is too much padding */}
+      <form class={`modal-body ${classes.modalBody}`} onSubmit={verifyName}>
+        <div>Are you sure you want to delete your team?</div>
+        <div class='form-section'>
+          <label>Type your team name:</label>
+          <input placeholder={teamName} value={inputName} onChange={handleInputNameChange} />
+        </div>
+        <div class={`${classes.controls}`}>
+          <div class='btn-container u-inline-block'>
+            <button class='btn-small' onClick={wrappedOnClose}>Cancel</button>
+          </div>
+          <div class='btn-container u-inline-block'>
+            <input type='submit' class='btn-small btn-danger outline' disabled={!isNameValid} value='Confirm' />
+          </div>
+        </div>
+      </form>
     </Modal>
   )
 })


### PR DESCRIPTION
Fix account deletion dialog's `modal-body` being inside of its `modal-header`, and adjusted styles to reduce unnecessary padding between elements of the dialog.

New dialog:
![desktop](https://user-images.githubusercontent.com/5903672/77497895-cd45c080-6e24-11ea-8e87-1383fbc5c856.png)
![mobile](https://user-images.githubusercontent.com/5903672/77497911-d5056500-6e24-11ea-819c-c0d9838093c3.png)

Old dialog:
![old mobile](https://user-images.githubusercontent.com/5903672/77497938-dfbffa00-6e24-11ea-9d3e-60ab6bf49b4e.png)

