### PR TITLE
Make account deletion dialog update when you type

### DIFF
--- a/client/src/pages/profile.js
+++ b/client/src/pages/profile.js
@@ -64,7 +64,7 @@ const DeleteModal = withStyles({
         <div>Are you sure you want to delete your team?</div>
         <div class='form-section'>
           <label>Type your team name:</label>
-          <input placeholder={teamName} value={inputName} onChange={handleInputNameChange} />
+          <input placeholder={teamName} value={inputName} onInput={handleInputNameChange} />
         </div>
         <div class={`${classes.controls}`}>
           <div class='btn-container u-inline-block'>


### PR DESCRIPTION
Event handler for controlled `input` element in the form in the account deletion dialog for confirming team name used the wrong event (`onChange` only fires when the user is done editing rather than as they are typing). Fix this so that the "Confirm" button will reactivate as soon as the correct team name is typed in the dialog.