### PR TITLE
Enforce no blank lines at beginning of file

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,5 +14,10 @@ module.exports = {
   plugins: [
   ],
   rules: {
+    'no-multiple-empty-lines': ['error', {
+      max: 1,
+      maxEOF: 0,
+      maxBOF: 0
+    }]
   }
 }

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -12,6 +12,11 @@ module.exports = {
   plugins: [
   ],
   rules: {
-    radix: 'off'
+    radix: 'off',
+    'no-multiple-empty-lines': ['error', { // override again because of reincluding standard
+      max: 1,
+      maxEOF: 0,
+      maxBOF: 0
+    }]
   }
 }

--- a/client/src/components/header.js
+++ b/client/src/components/header.js
@@ -1,4 +1,3 @@
-
 import withStyles from './jss'
 
 export default withStyles({

--- a/server/util/index.js
+++ b/server/util/index.js
@@ -1,4 +1,3 @@
-
 const config = require('../../config/server')
 const path = require('path')
 const fs = require('fs')


### PR DESCRIPTION
Until we can stop re-including standard in the client config due to preact's style configs accidentally being included, the rule needs to be redeclared in the client eslintrc since loading standard clears the BOF option.