### PR TITLE
fix(build): overwrite files when copying static files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:slim": "ava",
     "test:report": "nyc --skip-full --reporter=lcov ava",
     "commit": "git cz",
-    "copy-static": "sh -c \"cpy 'server/**/*' '.rdeploy' '!**/*.ts' dist/ --no-overwrite --parents\""
+    "copy-static": "sh -c \"cpy 'server/**/*' '.rdeploy' '!**/*.ts' dist/ --parents\""
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Allow for overwriting of files so that changes to configuration (e.g. `.rdeploy`, `config/server.js`) are properly updated in dist/ when it is used by the server.