### PR TITLE
fix: make migrate down work on migrations

### DIFF
--- a/migrations/1581725957097_del-password.js
+++ b/migrations/1581725957097_del-password.js
@@ -2,8 +2,4 @@ exports.up = function (pgm) {
   pgm.dropColumns('users', ['password'])
 }
 
-exports.down = function (pgm) {
-  pgm.addColumns('users', {
-    password: { type: 'string', notNull: true }
-  })
-}
+exports.down = false

--- a/migrations/1582424634372_string-uuids.js
+++ b/migrations/1582424634372_string-uuids.js
@@ -5,7 +5,7 @@ exports.up = function (pgm) {
 }
 
 exports.down = function (pgm) {
-  pgm.alterColumn('users', 'id', { type: 'uuid' })
-  pgm.alterColumn('solves', 'id', { type: 'uuid' })
-  pgm.alterColumn('solves', 'userid', { type: 'uuid' })
+  pgm.alterColumn('users', 'id', { type: 'uuid', using: 'id::uuid' })
+  pgm.alterColumn('solves', 'id', { type: 'uuid', using: 'id::uuid' })
+  pgm.alterColumn('solves', 'userid', { type: 'uuid', using: 'id::uuid' })
 }

--- a/migrations/1585799727940_add-ctftime-id.js
+++ b/migrations/1585799727940_add-ctftime-id.js
@@ -7,7 +7,7 @@ exports.up = function (pgm) {
 }
 
 exports.down = function (pgm) {
-  pgm.dropColumns('users', ['ctftime_id'])
-  pgm.alterColumn('users', 'email', { notNull: true })
   pgm.dropConstraint('users', 'require_email_or_ctftime_id')
+  pgm.alterColumn('users', 'email', { notNull: true })
+  pgm.dropColumns('users', ['ctftime_id'])
 }


### PR DESCRIPTION
Ensure that irreversible migrations are marked as such, that type conversions are implemented correctly, and that the changes are executed in the right order.