### PR TITLE
feat(client): restyle or divider in login / register

### DIFF
--- a/client/src/components/ctftime-button.js
+++ b/client/src/components/ctftime-button.js
@@ -13,27 +13,6 @@ export default withStyles({
     '& svg': {
       width: '150px'
     }
-  },
-  or: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    margin: '15px auto',
-    maxWidth: '500px',
-    '&::before, &::after': {
-      display: 'block',
-      content: '""',
-      flex: '1 0 0',
-      height: '0.05rem',
-      backgroundColor: 'var(--cirrus-fg)',
-      opacity: 0.2
-    },
-    '& > *': {
-      marginLeft: 'var(--gap-4)',
-      marginRight: 'var(--gap-4)',
-      fontVariant: 'small-caps',
-      fontSize: '1.0rem'
-    }
   }
 }, withToast(class CtftimeButton extends Component {
   componentDidMount () {
@@ -76,9 +55,6 @@ export default withStyles({
   render ({ classes, ...props }) {
     return (
       <div {...props} >
-        <div class={classes.or}>
-          <h6>or</h6>
-        </div>
         <button class={classes.ctftimeButton} onClick={this.handleClick}>
           <Ctftime />
         </button>

--- a/client/src/components/ctftime-button.js
+++ b/client/src/components/ctftime-button.js
@@ -15,9 +15,25 @@ export default withStyles({
     }
   },
   or: {
-    textAlign: 'center',
-    display: 'block',
-    margin: '15px auto'
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    margin: '15px auto',
+    maxWidth: '500px',
+    '&::before, &::after': {
+      display: 'block',
+      content: '""',
+      flex: '1 0 0',
+      height: '0.05rem',
+      backgroundColor: 'var(--cirrus-fg)',
+      opacity: 0.2
+    },
+    '& > *': {
+      marginLeft: 'var(--gap-4)',
+      marginRight: 'var(--gap-4)',
+      fontVariant: 'small-caps',
+      fontSize: '1.0rem'
+    }
   }
 }, withToast(class CtftimeButton extends Component {
   componentDidMount () {
@@ -61,7 +77,7 @@ export default withStyles({
     return (
       <div {...props} >
         <div class={classes.or}>
-          <h5>or</h5>
+          <h6>or</h6>
         </div>
         <button class={classes.ctftimeButton} onClick={this.handleClick}>
           <Ctftime />

--- a/client/src/components/or.js
+++ b/client/src/components/or.js
@@ -1,0 +1,33 @@
+import withStyles from '../components/jss'
+
+export default withStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    margin: '15px auto',
+    maxWidth: '500px',
+    '&::before, &::after': {
+      display: 'block',
+      content: '""',
+      flex: '1 0 0',
+      height: '0',
+      borderTop: '1px solid var(--cirrus-fg)',
+      opacity: 0.2
+    },
+    '& > *': {
+      marginLeft: 'var(--gap-4)',
+      marginRight: 'var(--gap-4)',
+      fontVariant: 'small-caps',
+      fontSize: '1.0rem'
+    }
+  }
+}, ({ classes, ...props }) => {
+  return (
+    <div class='col-12' {...props} >
+      <div class={classes.root}>
+        <h6>or</h6>
+      </div>
+    </div>
+  )
+})

--- a/client/src/routes/login.js
+++ b/client/src/routes/login.js
@@ -9,6 +9,7 @@ import IdCard from '../icons/id-card.svg'
 import { route } from 'preact-router'
 import CtftimeButton from '../components/ctftime-button'
 import CtftimeAdditional from '../components/ctftime-additional'
+import AuthOr from '../components/or'
 
 export default withStyles({
   root: {
@@ -54,6 +55,7 @@ export default withStyles({
         <Form class={`${classes.root} col-6`} onSubmit={this.handleSubmit} disabled={disabledButton} buttonText='Login' errors={errors}>
           <input autofocus name='teamToken' icon={<IdCard />} placeholder='Team Token' type='text' value={teamToken} onChange={this.linkState('teamToken')} />
         </Form>
+        <AuthOr />
         <CtftimeButton class='col-12' onCtftimeDone={this.handleCtftimeDone} />
       </div>
     )

--- a/client/src/routes/registration.js
+++ b/client/src/routes/registration.js
@@ -9,6 +9,7 @@ import UserCircle from '../icons/user-circle.svg'
 import EnvelopeOpen from '../icons/envelope-open.svg'
 import CtftimeButton from '../components/ctftime-button'
 import CtftimeAdditional from '../components/ctftime-additional'
+import AuthOr from '../components/or'
 
 export default withStyles({
   root: {
@@ -53,6 +54,7 @@ export default withStyles({
             }
           </select>
         </Form>
+        <AuthOr />
         <CtftimeButton class='col-12' onCtftimeDone={this.handleCtftimeDone} />
       </div>
     )


### PR DESCRIPTION
Use Spotify-style or with dividing line between token / email login / signup and ctftime OAuth button.

![screenshot](https://user-images.githubusercontent.com/5903672/79360939-9e49d880-7f12-11ea-9a41-c58f7669faea.png)

