### PR TITLE
Small cleanup fixes

### DIFF
--- a/client/lib/svg-icon-component-generator.js
+++ b/client/lib/svg-icon-component-generator.js
@@ -19,7 +19,7 @@ function stringifySymbolRequest (symbol, request) {
 }
 
 // From JetBrains/svg-sprite-loader/examples/custom-runtime-generator/
-module.exports = function runtimeGenerator ({ symbol, config, context, loaderContext }) {
+module.exports = function runtimeGenerator ({ symbol, config, loaderContext }) {
   const { spriteModule, symbolModule, runtimeOptions } = config
   const compilerContext = loaderContext._compiler.context
 

--- a/client/src/components/graph.js
+++ b/client/src/components/graph.js
@@ -10,6 +10,8 @@ const axis = 20
 const axisGap = 20
 const day = 24 * 60 * 60 * 1000
 
+const strokeHoverWidth = 12
+
 const timeToX = ({ minX, maxX, time, width }) => {
   return (time - minX) / (maxX - minX) * width
 }
@@ -61,8 +63,9 @@ const GraphLine = memo(({ points, onTooltipIn, onMouseMove, onMouseOut, name, cu
       pointer-events='none'
     />
     <polyline
-      stroke-width={stroke * 2.5}
+      stroke-width={strokeHoverWidth}
       points={points}
+      stroke-linecap='round'
       fill='transparent'
       pointer-events='stroke'
       onMouseOver={onTooltipIn(`${name} - ${currentScore} points`)}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:slim": "ava",
     "test:report": "nyc --skip-full --reporter=lcov ava",
     "commit": "git cz",
-    "copy-static": "sh -c \"cpy 'server/**/*' '.rdeploy' '!**/*.ts' dist/ --parents\""
+    "copy-static": "cpy 'server/**/*' '.rdeploy' '!**/*.{j,t}s' dist/ --parents"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Fix:
- unnecessary argument in svg-sprite-loader runtime generator
- `copy-static` script no longer overwrites `tsc` output for plain JS
- improvements to the graph line hover region