### PR TITLE
Render mustache in WDS (yarn dev)

### DIFF
--- a/client/lib/loaders/mustache-rendered-loader.js
+++ b/client/lib/loaders/mustache-rendered-loader.js
@@ -1,0 +1,6 @@
+const loaderUtils = require('loader-utils')
+const mustache = require('mustache')
+
+module.exports = function (source) {
+  return mustache.render(source, loaderUtils.getOptions(this))
+}

--- a/preact.config.js
+++ b/preact.config.js
@@ -1,8 +1,12 @@
 require('dotenv').config()
 
+const path = require('path')
 const glob = require('glob')
+const assert = require('assert').strict
 
 const PurgecssPlugin = require('purgecss-webpack-plugin')
+
+const clientConfig = require('./config/client.js')
 
 export default (config, env, helpers) => {
   if (env.production) {
@@ -13,6 +17,8 @@ export default (config, env, helpers) => {
       '/api': 'http://localhost:3000'
     }
   }
+
+  config.resolveLoader.modules.unshift(path.resolve(__dirname, 'client/lib/loaders'))
 
   // The webpack base config has minicssextractplugin already loaded
   config.plugins.push(
@@ -59,6 +65,23 @@ export default (config, env, helpers) => {
         }
         return filename.slice(0, match.index) + '.' + match[1]
       }
+    }
+  }
+
+  if (!env.production) {
+    const HtmlWebpackPluginsWrappers = helpers.getPluginsByName(config, 'HtmlWebpackPlugin')
+    for (const HtmlWebpackPluginWrapper of HtmlWebpackPluginsWrappers) {
+      const options = HtmlWebpackPluginWrapper.plugin.options
+      assert(/^!!ejs-loader!/.test(options.template))
+
+      // FIXME: refactor this (copy-pasted from server)
+      const context = {
+        config: JSON.stringify(clientConfig),
+        ctfName: clientConfig.ctfName,
+        meta: clientConfig.meta
+      }
+
+      options.template = `!!ejs-loader!mustache-rendered-loader?${JSON.stringify(context)}!${options.template.substr(13)}`
     }
   }
 }

--- a/preact.config.js
+++ b/preact.config.js
@@ -72,7 +72,8 @@ export default (config, env, helpers) => {
     const HtmlWebpackPluginsWrappers = helpers.getPluginsByName(config, 'HtmlWebpackPlugin')
     for (const HtmlWebpackPluginWrapper of HtmlWebpackPluginsWrappers) {
       const options = HtmlWebpackPluginWrapper.plugin.options
-      assert(/^!!ejs-loader!/.test(options.template))
+      const loaderMatch = options.template.match(/^!!ejs-loader!(.*)$/)
+      assert(loaderMatch !== null)
 
       // FIXME: refactor this (copy-pasted from server)
       const context = {
@@ -81,7 +82,7 @@ export default (config, env, helpers) => {
         meta: clientConfig.meta
       }
 
-      options.template = `!!ejs-loader!mustache-rendered-loader?${JSON.stringify(context)}!${options.template.substr(13)}`
+      options.template = `!!ejs-loader!mustache-rendered-loader?${JSON.stringify(context)}!${loaderMatch[1]}`
     }
   }
 }


### PR DESCRIPTION
When in dev mode, render the Mustache templates in `index.html` within Webpack; this fixes `yarn dev`.

Currently the context for the mustache template is copy-pasted from the server rendering code.