### PR TITLE
fix(build): remove yarn caches from docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:12.16.3-buster-slim AS build
 WORKDIR /app
 
 COPY package.json yarn.lock ./
-RUN yarn
+RUN yarn install --frozen-lockfile && yarn cache clean
 
 COPY . .
 RUN yarn build
@@ -10,10 +10,11 @@ RUN yarn build
 FROM node:12.16.3-buster-slim AS run
 WORKDIR /app
 
-COPY --from=build /app/dist /app/dist
 COPY --from=build /app/yarn.lock /app/package.json /app/
 
 ENV NODE_ENV production
-RUN yarn
+RUN yarn install --prod --frozen-lockfile && yarn cache clean
+
+COPY --from=build /app/dist /app/dist
 
 CMD ["node", "/app/dist/server/index.js"]


### PR DESCRIPTION
Clear yarn caches in docker build. Also use `--frozen-lockfile` flag to ensure lockfile consistency, and explicit `--prod` flag.

Image reduced to ~13MB own size