### PR TITLE
fix(client): fix updateAccount sending invalid payload

### DIFF
--- a/client/src/api/profile.js
+++ b/client/src/api/profile.js
@@ -23,7 +23,7 @@ export const deleteAccount = () => {
 export const updateAccount = ({ name, division }) => {
   return request('PATCH', '/users/me', {
     name,
-    division: Number.parseInt(division)
+    division: division === undefined ? undefined : Number.parseInt(division)
   })
     .then(resp => {
       switch (resp.kind) {


### PR DESCRIPTION
Fixed updateAccount sending `null` for `division`, creating an invalid request,  when no division was provided to the function.