### PR TITLE
fix(build): only require client config when needed

### DIFF
--- a/preact.config.js
+++ b/preact.config.js
@@ -6,8 +6,6 @@ const assert = require('assert').strict
 
 const PurgecssPlugin = require('purgecss-webpack-plugin')
 
-const clientConfig = require('./config/client.js')
-
 export default (config, env, helpers) => {
   if (env.production) {
     // Disable sourcemaps
@@ -72,6 +70,8 @@ export default (config, env, helpers) => {
   }
 
   if (!env.production) {
+    const clientConfig = require('./config/client.js')
+
     const HtmlWebpackPluginsWrappers = helpers.getPluginsByName(config, 'HtmlWebpackPlugin')
     for (const HtmlWebpackPluginWrapper of HtmlWebpackPluginsWrappers) {
       const options = HtmlWebpackPluginWrapper.plugin.options


### PR DESCRIPTION
Require client config in preact build only when running in dev mode. This allows the container to be built without needing to have a client config present.