### PR TITLE
feat(server): parse real IP from Cloudflare headers

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -2,14 +2,29 @@ import path from 'path'
 import fastify from 'fastify'
 import fastifyStatic from 'fastify-static'
 import helmet from 'fastify-helmet'
-import { enableCORS, serveIndex } from './util'
+import { enableCORS, serveIndex, getRealIp } from './util'
 import { init as uploadProviderInit } from './uploads'
 import api from './api'
 
 const app = fastify({
   logger: {
-    level: process.env.NODE_ENV === 'production' ? 'info' : 'debug'
+    level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+    serializers: {
+      // From https://github.com/fastify/fastify/blob/2.x/lib/logger.js#L54
+      req: (req) => ({
+        method: req.method,
+        url: req.url,
+        version: req.headers['accept-version'],
+        hostname: req.hostname,
+        remoteAddress: getRealIp(req),
+        remotePort: req.connection.remotePort
+      })
+    }
   }
+})
+
+app.addHook('onRequest', async (req, reply) => {
+  req.ip = getRealIp(req)
 })
 
 app.register(enableCORS)

--- a/server/util/index.js
+++ b/server/util/index.js
@@ -55,3 +55,8 @@ export const serveIndex = async (fastify, opts) => {
   fastify.get('/index.html', routeHandler)
   fastify.setNotFoundHandler(routeHandler)
 }
+
+// Parse Cloudflare CF-Connecting-IP header
+export const getRealIp = (req) => {
+  return req.headers['cf-connecting-ip'] || req.ip
+}


### PR DESCRIPTION
Since Fastify does not have any hooks that run before the request is logged, we have to override the request serializer to modify `req.ip` in the logged request data. We also register a hook as early as possible to modify the real `req.ip`. The serializer is copied from the default implemenation in Fastify.