### PR TITLE
fix(client): remove preact-cli's manifest.json

### DIFF
--- a/preact.config.js
+++ b/preact.config.js
@@ -79,4 +79,12 @@ export default (config, env, helpers) => {
       options.template = `!!ejs-loader!mustache-config-loader!${loaderMatch[1]}`
     }
   }
+
+  const CopyPluginWrapper = helpers.getPluginsByName(config, 'CopyPlugin')[0]
+  if (CopyPluginWrapper !== undefined) {
+    const plugin = CopyPluginWrapper.plugin
+    plugin.patterns = plugin.patterns.filter(({ from }) => {
+      return /node-modules\/preact-cli.*resources\/(manifest.json|icon.png)/.test(from)
+    })
+  }
 }


### PR DESCRIPTION
This uses regex to find and remove the rules for copying preact-cli's default manifest.json and associated icon; this may require updating if preact-cli changes how the manifest is created.