### PR TITLE
fix: prevent nodemon from reloading unless server changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "commit": "git cz",
     "copy-static": "cpy \"server/**/*\" \"!**/*.{j,t}s\" \"migrations\" dist/ --parents"
   },
+  "nodemonConfig": {
+    "watch": ["dist/server", "dist/config", "dist/build/index.html"]
+  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"


### PR DESCRIPTION
Tell nodemon to ignore everything except for tsc build outputs used by the server.