### PR TITLE
feat(client): open challenge links in new tab

### DIFF
--- a/client/src/components/markdown.js
+++ b/client/src/components/markdown.js
@@ -17,12 +17,12 @@ const snarkdownEnhanced = (md) => {
   return htmls.join('\n\n')
 }
 
-const Markdown = ({ content }) => (
+const Markdown = ({ content, components }) => (
   <Markup
     type='html'
     trim={false}
     markup={snarkdownEnhanced(content)}
-    components={{ Timer, Sponsors, ActionButton }}
+    components={{ Timer, Sponsors, ActionButton, ...components }}
   />
 )
 

--- a/client/src/components/problem.js
+++ b/client/src/components/problem.js
@@ -5,6 +5,12 @@ import { submitFlag } from '../api/challenges'
 import { useToast } from '../components/toast'
 import Markdown from '../components/markdown'
 
+const ExternalLink = (props) => <a {...props} target='_blank' />
+
+const markdownComponents = {
+  A: ExternalLink
+}
+
 const Problem = ({ classes, problem, solved, setSolved }) => {
   const { toast } = useToast()
 
@@ -48,7 +54,7 @@ const Problem = ({ classes, problem, solved, setSolved }) => {
         <div class='content-no-padding u-center'><div class={`divider ${classes.divider}`} /></div>
 
         <div class={`${classes.description} frame__subtitle`}>
-          <Markdown content={problem.description} />
+          <Markdown content={problem.description} components={markdownComponents} />
         </div>
         <form class='form-section' onSubmit={handleSubmit}>
           <div class='form-group'>


### PR DESCRIPTION
Add `target="_blank"` attribute to all links in challenge Markdown description.