### PR TITLE
feat(client): save scoreboard settings on client

### DIFF
--- a/client/src/routes/challs.js
+++ b/client/src/routes/challs.js
@@ -15,7 +15,7 @@ const loadStates = {
 }
 
 const Challenges = ({ classes }) => {
-  const challPageState = JSON.parse(localStorage.challPageState || '{}')
+  const challPageState = useMemo(() => JSON.parse(localStorage.getItem('challPageState') || '{}'), [])
   const [problems, setProblems] = useState([])
   const [categories, setCategories] = useState(challPageState.categories || {})
   const [showSolved, setShowSolved] = useState(challPageState.showSolved || false)

--- a/client/src/routes/scoreboard.js
+++ b/client/src/routes/scoreboard.js
@@ -34,9 +34,9 @@ const Scoreboard = withStyles({
     paddingTop: '1.5em'
   },
   selected: {
-    backgroundColor: 'rgba(0, 0, 0, 0.05)',
+    backgroundColor: 'rgba(216,216,216,.07)',
     '&:hover': {
-      backgroundColor: 'rgba(0, 0, 0, 0.1) !important'
+      backgroundColor: 'rgba(216,216,216,.20) !important'
     }
   },
   table: {


### PR DESCRIPTION
Use localstorage to save "preferences" (division + page size), and use query string parameters to make absolute links to scoreboard pages (which includes division and page size). The query string is updated if the current scoreboard page is not 1, or there previously was a query string.