### PR TITLE
fix(server): add error message for malformed data uris

### DIFF
--- a/server/api/admin/upload/post.js
+++ b/server/api/admin/upload/post.js
@@ -45,7 +45,7 @@ export default {
         }
       })
     } catch (e) {
-      return responses.badDataURI
+      return responses.badDataUri
     }
 
     try {

--- a/server/api/admin/upload/post.js
+++ b/server/api/admin/upload/post.js
@@ -36,11 +36,22 @@ export default {
   bodyLimit: 2 ** 30, // 1 GiB
   handler: async ({ req }) => {
     const uploadProvider = getUploadProvider()
+    let convertedFiles
+    try {
+      convertedFiles = req.body.files.map(({ name, data }) => {
+        return {
+          name,
+          data: toBuffer(data)
+        }
+      })
+    } catch (e) {
+      return responses.badDataURI
+    }
 
     try {
       const files = await Promise.all(
-        req.body.files.map(async ({ name, data }) => {
-          const url = await uploadProvider.upload(toBuffer(data), name)
+        convertedFiles.map(async ({ name, data }) => {
+          const url = await uploadProvider.upload(data, name)
 
           return {
             name,

--- a/server/responses/index.js
+++ b/server/responses/index.js
@@ -119,7 +119,7 @@ export const responseList = {
     status: 500,
     message: 'The upload of files failed'
   },
-  badDataURI: {
+  badDataUri: {
     status: 400,
     message: 'A data URI provided was malformed'
   },

--- a/server/responses/index.js
+++ b/server/responses/index.js
@@ -117,7 +117,11 @@ export const responseList = {
   },
   badFilesUpload: {
     status: 500,
-    message: 'The message upload failed'
+    message: 'The upload of files failed'
+  },
+  badDataURI: {
+    status: 400,
+    message: 'A data URI provided was malformed'
   },
   badBody: {
     status: 400,


### PR DESCRIPTION
The current implementation of the file upload endpoint does not distinguish between errors from the upload provider, and errors from a malformed data URI provided by the user (see #300).
This commit changes the behavior of the file upload endpoint to convert the data URIs synchronously first, returning a status code of 400 and an appropriate error if any data URI conversion fails.
This commit also updates the message for a failed upload that failed for reasons other than a user error.

fix #300