### PR TITLE
fix: clean up package.json scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "lint": "sh -c \"tsc --noEmit ; eslint .\"",
     "lint:strict": "sh -c \"tsc --noEmit -p tsconfig.strict.json ; eslint .\"",
-    "start": "node --enable-source-maps dist/server/index.js",
-    "migrate": "sh -c \"yarn build:ts && RCTF_DATABASE_MIGRATE=only yarn start\"",
+    "start": "node --enable-source-maps --unhandled-rejections=strict dist/server/index.js",
+    "migrate": "yarn build:ts && cross-env RCTF_DATABASE_MIGRATE=only yarn start",
     "build:client": "preact build --src client/src --template client/index.html --dest dist/build --no-prerender --no-inline-css",
     "build:ts": "tsc && yarn copy-static",
     "build": "yarn build:ts && yarn build:client",


### PR DESCRIPTION
Use strict unhandled promise rejections (like in Dockerfile) in `yarn start`, and drop unnecessary use of `sh` in `yarn migrate`.
