### PR TITLE
feat(server): add config option for proxy trust

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -73,6 +73,8 @@ Configuration for advanced users - sane defaults are automatically set by the in
 YAML/JSON name|environment name|required|default value|type|description
 -|-|-|-|-|-
 `tokenKey`|`RCTF_TOKEN_KEY`|yes|_(none)_|string|base64 encoded 32 byte key used for encrypting tokens
+`proxy.cloudflare`|_(none)_|yes|`false`|boolean|whether or not rCTF is behind Cloudflare; if `true`, do not use `proxy.trust`
+`proxy.trust`|_(none)_|yes|`false`|boolean, string, string array, or integer|X-Forwarded-For trust: the trust parameter to [proxy-addr](https://www.npmjs.com/package/proxy-addr)
 `loginTimeout`|`RCTF_LOGIN_TIMEOUT`|yes|3600000|integer|lifetime of registration, email update, and recovery links, in milliseconds
 `userMembers`|`RCTF_USER_MEMBERS`|yes|`true`|boolean|whether to allow a user to provide emails for individual members 
 `database.migrate`|`RCTF_DATABASE_MIGRATE`|yes|`never`|`before | only | never`|how to run postgreSQL migrations. [documentation](management/migration.md)

--- a/server/app.js
+++ b/server/app.js
@@ -3,11 +3,13 @@ import fastify from 'fastify'
 import fastifyStatic from 'fastify-static'
 import helmet from 'fastify-helmet'
 import hyperid from 'hyperid'
+import config from './config/server'
 import { serveIndex, getRealIp } from './util'
 import { init as uploadProviderInit } from './uploads'
 import api, { logSerializers as apiLogSerializers } from './api'
 
 const app = fastify({
+  trustProxy: config.proxy.trust,
   logger: {
     level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
     serializers: {

--- a/server/config/server.ts
+++ b/server/config/server.ts
@@ -39,6 +39,12 @@ export type ServerConfig = {
   tokenKey: string;
   origin: string;
 
+  // TODO: enforce `trust` is false when `cloudflare` is true
+  proxy: {
+    cloudflare: boolean
+    trust: boolean | string | string[] | number
+  }
+
   ctftime?: {
     clientId: string;
     clientSecret: string;
@@ -165,6 +171,10 @@ const defaultConfig: PartialDeep<ServerConfig> = {
   },
   uploadProvider: {
     name: 'uploads/local'
+  },
+  proxy: {
+    cloudflare: false,
+    trust: false
   },
   meta: {
     description: '',


### PR DESCRIPTION
Add configurable setting for trusting `Cf-Connecting-Ip` header and `X-Forwarded-For` parsing.

Closes #430 