### PR TITLE
ci: enforce commit message conventions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,13 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v2
+        with:
+          # Fetch all history
+          fetch-depth: 0
 
       - name: Check commit messages
         run: |
-          scripts/check-commits.sh ${{ github.base_ref }} ${{ github.head_ref }}
+          scripts/check-commits.sh ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}
 
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,16 @@ on:
   pull_request:
 
 jobs:
+  check-commits:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check commit messages
+        run: |
+          scripts/check-commits.sh ${{ github.base_ref }} ${{ github.head_ref }}
+
   shellcheck:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,6 @@ You should follow the examples below as a guideline for how to name your branche
 ```
 feature/brief-description-here
 fix/bug-description
-style/some-frontend-component
 refactor/some-component
-add/contributing-md
+docs/some-component
 ```

--- a/scripts/check-commits.sh
+++ b/scripts/check-commits.sh
@@ -3,6 +3,8 @@
 set -eo pipefail
 
 do_check() {
+	set -eo pipefail
+
 	base="$1"
 	head="$2"
 	log="$(git log --pretty='format:%h %s' --no-merges "${base}..${head}")"

--- a/scripts/check-commits.sh
+++ b/scripts/check-commits.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -eo pipefail
+
+do_check() {
+	base="$1"
+	head="$2"
+	log="$(git log --pretty='format:%h %s' --no-merges "${base}..${head}")"
+	if [ -z "$log" ]; then
+		echo 'WARNING: no commits in specified range' >&2
+	fi
+	grep -vE '^[0-9a-f]+ (feat|fix|refactor|docs|chore|build|test|ci|style)(\([a-zA-Z-]+\))?:' <<<"$log" || true
+}
+
+if [ $# -ne 2 ]; then
+	cat >&2 <<EOF
+Usage:
+    $0 BASE HEAD
+EOF
+	exit 1
+fi
+
+output="$(do_check "$1" "$2")"
+if [ -n "$output" ]; then
+	echo 'Bad commit messages:'
+	echo "$output"
+	exit 1
+else
+	echo 'All commit messages OK'
+fi


### PR DESCRIPTION
Add script to run in CI on pull request to enforce commit message summary lines match the conventions specified in CONTRIBUTING.md.

Also update outdated branch names in CONTRIBUTING.md
