### PR TITLE
docs: add docs for sponsors cards

### DIFF
--- a/docs/content/management/home.md
+++ b/docs/content/management/home.md
@@ -5,7 +5,7 @@ The home page of your CTF can be configured with various content in markdown and
 In addition to normal HTML, you can use some custom elements.
 
 - `<timer></timer>`: a countdown timer until the beginning or end of the CTF
-- `<sponsors></sponsors>`: a list of sponsor cards
+- `<sponsors></sponsors>`: a list of sponsor cards ([see configuration](#sponsor-cards))
 - `<action-button></action-button>`: a button with hover effects, generally used as a link to `/register`
 
 ```yaml
@@ -26,4 +26,36 @@ homeContent: |
   Thank you to our wonderful sponsors for making this event possible!
 
   <sponsors></sponsors>
+```
+
+## Sponsor Cards
+
+The `<sponsors>` element can be used to display cards for the sponsors listed in
+the config under `sponsors`.
+
+### Configuration
+
+The `sponsors` key takes an array of sponsor elements, which are each an object
+with the following properties:
+
+| Key           | Default  | Description                       |
+| ------------- | -------- | --------------------------------- |
+| `name`        | _(none)_ | sponsor name                      |
+| `icon`        | _(none)_ | sponsor icon URL                  |
+| `description` | _(none)_ | sponsor description               |
+| `small`       | `false`  | whether to show as a compact card |
+
+### Example
+
+```yaml
+sponsors:
+  - name: Foo
+    icon: https://example.com/foo.png
+    description: |
+      An excellent sponsor
+  - name: Bar
+    icon: https://example.com/bar.png
+    description: |
+      An excellent sponsor
+    small: true
 ```


### PR DESCRIPTION
Added description about the options that were missing.

Cherry-picked and squashed from PR #520 (originally created by @pr0PM)
