### PR TITLE
ci: update node to 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12]
+        node: [14]
     steps:
       - uses: actions/checkout@v2
 
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12]
+        node: [14]
         postgres: [12]
         redis: [6]
     services:


### PR DESCRIPTION
Docker images use node 14, so update CI jobs to match.
