### PR TITLE
refactor(server): clean up getting array element types

### DIFF
--- a/packages/server/src/api/helpers.ts
+++ b/packages/server/src/api/helpers.ts
@@ -41,9 +41,6 @@ import { User, getUserById } from '../database/users'
 
 const responseObjects = _responseObjects as Responses
 
-// FIXME: consolidate with duplicate in database/util
-type ArrayValue<Arr> = Arr extends (infer Val)[] ? Val : Arr
-
 type GetFastifyRouteGenericForRoute<
   Route extends ApiRoute
 > = FastifyRouteGenericInterface & {
@@ -154,7 +151,7 @@ export function makeResponseFactories<ResponseKinds extends keyof Responses>(
 
 interface HandlerBaseArgs<Route extends ApiRoute> {
   req: FastifyRequest<GetFastifyRouteGenericForRoute<Route>>
-  res: HandlerResponseFactories<ArrayValue<Route['responses']>>
+  res: HandlerResponseFactories<Route['responses'][number]>
 }
 
 export type HandlerArgs<Route extends ApiRoute> = HandlerBaseArgs<Route> &

--- a/packages/server/src/api/leaderboard/graph.ts
+++ b/packages/server/src/api/leaderboard/graph.ts
@@ -2,7 +2,6 @@ import { leaderboardGraphGet } from '@rctf/api-types/routes'
 import { makeFastifyRoute } from '../helpers'
 import { getGraph } from '../../cache/leaderboard'
 import config from '../../config/server'
-import { ValueOf } from 'type-fest'
 
 export default makeFastifyRoute(
   leaderboardGraphGet,
@@ -20,8 +19,8 @@ export default makeFastifyRoute(
     const reducedGraph = graph.map(user => {
       const { points } = user
       const reducedPoints = points.filter((point, i) => {
-        const prev = points[i - 1] as ValueOf<typeof points, number> | undefined
-        const next = points[i + 1] as ValueOf<typeof points, number> | undefined
+        const prev = points[i - 1] as typeof points[number] | undefined
+        const next = points[i + 1] as typeof points[number] | undefined
         return !(
           prev &&
           next &&

--- a/packages/server/src/api/users/util.ts
+++ b/packages/server/src/api/users/util.ts
@@ -8,14 +8,13 @@ import {
   GetScoreResponse,
   GetChallengeInfoResponse,
 } from '../../cache/leaderboard'
-import { ValueOf } from 'type-fest'
 
 export type UserSolvesData = Pick<
   CleanedChallenge,
   'category' | 'name' | 'id'
 > &
-  Pick<ValueOf<GetChallengeInfoResponse, number>, 'solves'> & {
-    points: ValueOf<GetChallengeInfoResponse, number>['score']
+  Pick<GetChallengeInfoResponse[number], 'solves'> & {
+    points: GetChallengeInfoResponse[number]['score']
     createdAt: number
   }
 


### PR DESCRIPTION
When getting the element type of an array type, use `Type[number]` where applicable. One instance of `ArrayValue` in database/util.ts was kept to work with the type potentially not being an array.