### PR TITLE
ci: add postgres 13 and windows to matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,26 @@ jobs:
           yarn typecheck
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: [14, 15]
+        node: [14]
         postgres: [12]
         redis: [6]
+        os: [ubuntu-latest]
+        include:
+          - node: 15
+            postgres: 12
+            redis: 6
+            os: ubuntu-latest
+          - node: 14
+            postgres: 13
+            redis: 6
+            os: ubuntu-latest
+          - node: 14
+            postgres: 12
+            redis: 6
+            os: windows-latest
     services:
       postgres:
         image: postgres:${{ matrix.postgres }}


### PR DESCRIPTION
Switch matrix to using `include` for "experimental" environments (a.k.a. those that aren't what is used with the docker-compose file or Helm chart), and add postgres 13 and windows.
