### PR TITLE
chore: backport ranking users with only tiebreakEligible: false

### DIFF
--- a/packages/server/src/leaderboard/calculate.ts
+++ b/packages/server/src/leaderboard/calculate.ts
@@ -148,6 +148,8 @@ export default ({
         (b.lastTiebreakEligibleSolve ?? Infinity)
       )
     }
+
+    if (a.lastSolve === undefined && b.lastSolve === undefined) return 0
     return (a.lastSolve ?? Infinity) - (b.lastSolve ?? Infinity)
   }
 

--- a/packages/server/src/leaderboard/calculate.ts
+++ b/packages/server/src/leaderboard/calculate.ts
@@ -6,6 +6,13 @@ import {
   InternalUserInfo,
   InternalGraphEntry,
 } from './types'
+import { Challenge } from '../challenges/types'
+
+type IntermediateUserInfo = InternalUserInfo & {
+  lastSolve: number | undefined
+  lastTiebreakEligibleSolve: number | undefined
+  solvedChallengeIds: Challenge['id'][]
+}
 
 export default ({
   solves,
@@ -27,7 +34,7 @@ export default ({
       score: 0,
     })
   }
-  const userInfos = new Map<InternalUserInfo['id'], InternalUserInfo>()
+  const userInfos = new Map<IntermediateUserInfo['id'], IntermediateUserInfo>()
   for (let i = 0; i < users.length; i++) {
     const user = users[i]
     userInfos.set(user.id, {
@@ -124,7 +131,7 @@ export default ({
     }
   }
 
-  const userCompare = (a: InternalUserInfo, b: InternalUserInfo) => {
+  const userCompare = (a: IntermediateUserInfo, b: IntermediateUserInfo) => {
     // sort the users by score
     // if two user's scores are the same, sort by last tiebreakEligible solve time
     // if neither user has any tiebreakEligible solves, sort by last solve time
@@ -167,10 +174,18 @@ export default ({
     })
   }
 
+  const cleanIntermediateInfo = ({
+    id,
+    name,
+    division,
+    score,
+  }: IntermediateUserInfo): InternalUserInfo => ({ id, name, division, score })
+
   calcScores(leaderboardUpdate)
   const leaderboard = Array.from(userInfos.values())
     .filter(userInfo => userInfo.lastSolve !== undefined)
     .sort(userCompare)
+    .map(cleanIntermediateInfo)
 
   return {
     leaderboard,

--- a/packages/server/src/leaderboard/types.ts
+++ b/packages/server/src/leaderboard/types.ts
@@ -13,9 +13,6 @@ export interface WorkerRequest {
 
 export type InternalUserInfo = Pick<User, 'id' | 'name' | 'division'> & {
   score: number
-  lastSolve: number | undefined
-  lastTiebreakEligibleSolve: number | undefined
-  solvedChallengeIds: Challenge['id'][]
 }
 
 export type UserInfo = Pick<InternalUserInfo, 'id' | 'name' | 'score'>

--- a/packages/server/src/leaderboard/types.ts
+++ b/packages/server/src/leaderboard/types.ts
@@ -13,7 +13,8 @@ export interface WorkerRequest {
 
 export type InternalUserInfo = Pick<User, 'id' | 'name' | 'division'> & {
   score: number
-  lastSolve: number
+  lastSolve: number | undefined
+  lastTiebreakEligibleSolve: number | undefined
   solvedChallengeIds: Challenge['id'][]
 }
 

--- a/packages/server/test/unit/leaderboard/__snapshots__/calculate.ts.snap
+++ b/packages/server/test/unit/leaderboard/__snapshots__/calculate.ts.snap
@@ -100,13 +100,8 @@ Object {
     Object {
       "division": "div1",
       "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
-      "lastSolve": 14000,
-      "lastTiebreakEligibleSolve": 14000,
       "name": "a",
       "score": 100,
-      "solvedChallengeIds": Array [
-        "3195c55f-377a-4c78-924e-820e48d7674d",
-      ],
     },
   ],
   "leaderboardUpdate": 15000,
@@ -278,24 +273,14 @@ Object {
     Object {
       "division": "div1",
       "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
-      "lastSolve": 14000,
-      "lastTiebreakEligibleSolve": 14000,
       "name": "a",
       "score": 100,
-      "solvedChallengeIds": Array [
-        "3195c55f-377a-4c78-924e-820e48d7674d",
-      ],
     },
     Object {
       "division": "div2",
       "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
-      "lastSolve": 16000,
-      "lastTiebreakEligibleSolve": 16000,
       "name": "b",
       "score": 100,
-      "solvedChallengeIds": Array [
-        "3195c55f-377a-4c78-924e-820e48d7674d",
-      ],
     },
   ],
   "leaderboardUpdate": 20000,
@@ -389,24 +374,14 @@ Object {
     Object {
       "division": "div1",
       "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
-      "lastSolve": 14000,
-      "lastTiebreakEligibleSolve": 14000,
       "name": "a",
       "score": 100,
-      "solvedChallengeIds": Array [
-        "3195c55f-377a-4c78-924e-820e48d7674d",
-      ],
     },
     Object {
       "division": "div2",
       "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
-      "lastSolve": 16000,
-      "lastTiebreakEligibleSolve": 16000,
       "name": "b",
       "score": 100,
-      "solvedChallengeIds": Array [
-        "3195c55f-377a-4c78-924e-820e48d7674d",
-      ],
     },
   ],
   "leaderboardUpdate": 20000,
@@ -798,13 +773,8 @@ Object {
     Object {
       "division": "div1",
       "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
-      "lastSolve": 14000,
-      "lastTiebreakEligibleSolve": 14000,
       "name": "a",
       "score": 100,
-      "solvedChallengeIds": Array [
-        "3195c55f-377a-4c78-924e-820e48d7674d",
-      ],
     },
   ],
   "leaderboardUpdate": 15000,
@@ -963,25 +933,14 @@ Object {
     Object {
       "division": "div2",
       "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
-      "lastSolve": 18000,
-      "lastTiebreakEligibleSolve": 16000,
       "name": "b",
       "score": 101,
-      "solvedChallengeIds": Array [
-        "3195c55f-377a-4c78-924e-820e48d7674d",
-        "134785d3-08e7-48c5-99c0-18b966172636",
-      ],
     },
     Object {
       "division": "div1",
       "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
-      "lastSolve": 14000,
-      "lastTiebreakEligibleSolve": 14000,
       "name": "a",
       "score": 100,
-      "solvedChallengeIds": Array [
-        "3195c55f-377a-4c78-924e-820e48d7674d",
-      ],
     },
   ],
   "leaderboardUpdate": 19000,
@@ -1114,24 +1073,14 @@ Object {
     Object {
       "division": "div1",
       "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
-      "lastSolve": 14000,
-      "lastTiebreakEligibleSolve": 14000,
       "name": "a",
       "score": 100,
-      "solvedChallengeIds": Array [
-        "3195c55f-377a-4c78-924e-820e48d7674d",
-      ],
     },
     Object {
       "division": "div2",
       "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
-      "lastSolve": 16000,
-      "lastTiebreakEligibleSolve": 16000,
       "name": "b",
       "score": 100,
-      "solvedChallengeIds": Array [
-        "3195c55f-377a-4c78-924e-820e48d7674d",
-      ],
     },
   ],
   "leaderboardUpdate": 17000,
@@ -1303,26 +1252,14 @@ Object {
     Object {
       "division": "div1",
       "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
-      "lastSolve": 20000,
-      "lastTiebreakEligibleSolve": 14000,
       "name": "a",
       "score": 101,
-      "solvedChallengeIds": Array [
-        "3195c55f-377a-4c78-924e-820e48d7674d",
-        "134785d3-08e7-48c5-99c0-18b966172636",
-      ],
     },
     Object {
       "division": "div2",
       "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
-      "lastSolve": 18000,
-      "lastTiebreakEligibleSolve": 16000,
       "name": "b",
       "score": 101,
-      "solvedChallengeIds": Array [
-        "3195c55f-377a-4c78-924e-820e48d7674d",
-        "134785d3-08e7-48c5-99c0-18b966172636",
-      ],
     },
   ],
   "leaderboardUpdate": 20000,
@@ -1364,26 +1301,14 @@ Object {
     Object {
       "division": "div1",
       "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
-      "lastSolve": 20000,
-      "lastTiebreakEligibleSolve": 14000,
       "name": "a",
       "score": 101,
-      "solvedChallengeIds": Array [
-        "3195c55f-377a-4c78-924e-820e48d7674d",
-        "134785d3-08e7-48c5-99c0-18b966172636",
-      ],
     },
     Object {
       "division": "div2",
       "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
-      "lastSolve": 18000,
-      "lastTiebreakEligibleSolve": 16000,
       "name": "b",
       "score": 101,
-      "solvedChallengeIds": Array [
-        "3195c55f-377a-4c78-924e-820e48d7674d",
-        "134785d3-08e7-48c5-99c0-18b966172636",
-      ],
     },
   ],
   "leaderboardUpdate": 20000,
@@ -1512,13 +1437,8 @@ Object {
     Object {
       "division": "div2",
       "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
-      "lastSolve": 14000,
-      "lastTiebreakEligibleSolve": undefined,
       "name": "b",
       "score": 100,
-      "solvedChallengeIds": Array [
-        "134785d3-08e7-48c5-99c0-18b966172636",
-      ],
     },
   ],
   "leaderboardUpdate": 15000,
@@ -1690,24 +1610,14 @@ Object {
     Object {
       "division": "div1",
       "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
-      "lastSolve": 16000,
-      "lastTiebreakEligibleSolve": 16000,
       "name": "a",
       "score": 100,
-      "solvedChallengeIds": Array [
-        "3195c55f-377a-4c78-924e-820e48d7674d",
-      ],
     },
     Object {
       "division": "div2",
       "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
-      "lastSolve": 14000,
-      "lastTiebreakEligibleSolve": undefined,
       "name": "b",
       "score": 100,
-      "solvedChallengeIds": Array [
-        "134785d3-08e7-48c5-99c0-18b966172636",
-      ],
     },
   ],
   "leaderboardUpdate": 20000,
@@ -1801,24 +1711,14 @@ Object {
     Object {
       "division": "div1",
       "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
-      "lastSolve": 16000,
-      "lastTiebreakEligibleSolve": 16000,
       "name": "a",
       "score": 100,
-      "solvedChallengeIds": Array [
-        "3195c55f-377a-4c78-924e-820e48d7674d",
-      ],
     },
     Object {
       "division": "div2",
       "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
-      "lastSolve": 14000,
-      "lastTiebreakEligibleSolve": undefined,
       "name": "b",
       "score": 100,
-      "solvedChallengeIds": Array [
-        "134785d3-08e7-48c5-99c0-18b966172636",
-      ],
     },
   ],
   "leaderboardUpdate": 20000,
@@ -1947,13 +1847,8 @@ Object {
     Object {
       "division": "div1",
       "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
-      "lastSolve": 14000,
-      "lastTiebreakEligibleSolve": undefined,
       "name": "a",
       "score": 1,
-      "solvedChallengeIds": Array [
-        "134785d3-08e7-48c5-99c0-18b966172636",
-      ],
     },
   ],
   "leaderboardUpdate": 15000,
@@ -2086,24 +1981,14 @@ Object {
     Object {
       "division": "div1",
       "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
-      "lastSolve": 14000,
-      "lastTiebreakEligibleSolve": undefined,
       "name": "a",
       "score": 1,
-      "solvedChallengeIds": Array [
-        "134785d3-08e7-48c5-99c0-18b966172636",
-      ],
     },
     Object {
       "division": "div2",
       "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
-      "lastSolve": 16000,
-      "lastTiebreakEligibleSolve": undefined,
       "name": "b",
       "score": 1,
-      "solvedChallengeIds": Array [
-        "134785d3-08e7-48c5-99c0-18b966172636",
-      ],
     },
   ],
   "leaderboardUpdate": 17000,
@@ -2275,25 +2160,14 @@ Object {
     Object {
       "division": "div2",
       "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
-      "lastSolve": 18000,
-      "lastTiebreakEligibleSolve": 18000,
       "name": "b",
       "score": 214,
-      "solvedChallengeIds": Array [
-        "134785d3-08e7-48c5-99c0-18b966172636",
-        "3195c55f-377a-4c78-924e-820e48d7674d",
-      ],
     },
     Object {
       "division": "div1",
       "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
-      "lastSolve": 14000,
-      "lastTiebreakEligibleSolve": undefined,
       "name": "a",
       "score": 1,
-      "solvedChallengeIds": Array [
-        "134785d3-08e7-48c5-99c0-18b966172636",
-      ],
     },
   ],
   "leaderboardUpdate": 20000,
@@ -2361,25 +2235,14 @@ Object {
     Object {
       "division": "div2",
       "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
-      "lastSolve": 18000,
-      "lastTiebreakEligibleSolve": 18000,
       "name": "b",
       "score": 214,
-      "solvedChallengeIds": Array [
-        "134785d3-08e7-48c5-99c0-18b966172636",
-        "3195c55f-377a-4c78-924e-820e48d7674d",
-      ],
     },
     Object {
       "division": "div1",
       "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
-      "lastSolve": 14000,
-      "lastTiebreakEligibleSolve": undefined,
       "name": "a",
       "score": 1,
-      "solvedChallengeIds": Array [
-        "134785d3-08e7-48c5-99c0-18b966172636",
-      ],
     },
   ],
   "leaderboardUpdate": 20000,

--- a/packages/server/test/unit/leaderboard/__snapshots__/calculate.ts.snap
+++ b/packages/server/test/unit/leaderboard/__snapshots__/calculate.ts.snap
@@ -9,6 +9,12 @@ Object {
       "solves": 1,
       "tiebreakEligible": true,
     },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 1,
+      "solves": 0,
+      "tiebreakEligible": false,
+    },
   },
   "graphLeaderboards": Array [
     Object {
@@ -95,6 +101,7 @@ Object {
       "division": "div1",
       "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
       "lastSolve": 14000,
+      "lastTiebreakEligibleSolve": 14000,
       "name": "a",
       "score": 100,
       "solvedChallengeIds": Array [
@@ -115,6 +122,12 @@ Object {
       "solves": 2,
       "tiebreakEligible": true,
     },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 1,
+      "solves": 0,
+      "tiebreakEligible": false,
+    },
   },
   "graphLeaderboards": Array [
     Object {
@@ -266,6 +279,7 @@ Object {
       "division": "div1",
       "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
       "lastSolve": 14000,
+      "lastTiebreakEligibleSolve": 14000,
       "name": "a",
       "score": 100,
       "solvedChallengeIds": Array [
@@ -276,6 +290,7 @@ Object {
       "division": "div2",
       "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
       "lastSolve": 16000,
+      "lastTiebreakEligibleSolve": 16000,
       "name": "b",
       "score": 100,
       "solvedChallengeIds": Array [
@@ -295,6 +310,12 @@ Object {
       "score": 100,
       "solves": 2,
       "tiebreakEligible": true,
+    },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 1,
+      "solves": 0,
+      "tiebreakEligible": false,
     },
   },
   "graphLeaderboards": Array [
@@ -369,6 +390,7 @@ Object {
       "division": "div1",
       "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
       "lastSolve": 14000,
+      "lastTiebreakEligibleSolve": 14000,
       "name": "a",
       "score": 100,
       "solvedChallengeIds": Array [
@@ -379,6 +401,7 @@ Object {
       "division": "div2",
       "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
       "lastSolve": 16000,
+      "lastTiebreakEligibleSolve": 16000,
       "name": "b",
       "score": 100,
       "solvedChallengeIds": Array [
@@ -398,6 +421,12 @@ Object {
       "score": 500,
       "solves": 0,
       "tiebreakEligible": true,
+    },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 1,
+      "solves": 0,
+      "tiebreakEligible": false,
     },
   },
   "graphLeaderboards": Array [],
@@ -512,6 +541,12 @@ Object {
       "solves": 0,
       "tiebreakEligible": true,
     },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 1,
+      "solves": 0,
+      "tiebreakEligible": false,
+    },
   },
   "graphLeaderboards": Array [
     Object {
@@ -660,5 +695,1715 @@ Object {
   ],
   "leaderboard": Array [],
   "leaderboardUpdate": 20000,
+}
+`;
+
+exports[`E2E snapshots ranking tiebreakEligible false no tiebreak: Mid CTF no tie 1`] = `
+Object {
+  "challengeInfos": Map {
+    "3195c55f-377a-4c78-924e-820e48d7674d" => Object {
+      "id": "3195c55f-377a-4c78-924e-820e48d7674d",
+      "score": 100,
+      "solves": 1,
+      "tiebreakEligible": true,
+    },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 1,
+      "solves": 0,
+      "tiebreakEligible": false,
+    },
+  },
+  "graphLeaderboards": Array [
+    Object {
+      "sample": 10000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 11000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 12000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 13000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 14000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 15000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+  ],
+  "leaderboard": Array [
+    Object {
+      "division": "div1",
+      "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+      "lastSolve": 14000,
+      "lastTiebreakEligibleSolve": 14000,
+      "name": "a",
+      "score": 100,
+      "solvedChallengeIds": Array [
+        "3195c55f-377a-4c78-924e-820e48d7674d",
+      ],
+    },
+  ],
+  "leaderboardUpdate": 15000,
+}
+`;
+
+exports[`E2E snapshots ranking tiebreakEligible false no tiebreak: Mid CTF one tiebreak 1`] = `
+Object {
+  "challengeInfos": Map {
+    "3195c55f-377a-4c78-924e-820e48d7674d" => Object {
+      "id": "3195c55f-377a-4c78-924e-820e48d7674d",
+      "score": 100,
+      "solves": 2,
+      "tiebreakEligible": true,
+    },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 1,
+      "solves": 1,
+      "tiebreakEligible": false,
+    },
+  },
+  "graphLeaderboards": Array [
+    Object {
+      "sample": 10000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 11000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 12000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 13000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 14000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 15000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 16000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+    Object {
+      "sample": 17000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+    Object {
+      "sample": 18000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 101,
+        },
+      ],
+    },
+    Object {
+      "sample": 19000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 101,
+        },
+      ],
+    },
+  ],
+  "leaderboard": Array [
+    Object {
+      "division": "div2",
+      "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+      "lastSolve": 18000,
+      "lastTiebreakEligibleSolve": 16000,
+      "name": "b",
+      "score": 101,
+      "solvedChallengeIds": Array [
+        "3195c55f-377a-4c78-924e-820e48d7674d",
+        "134785d3-08e7-48c5-99c0-18b966172636",
+      ],
+    },
+    Object {
+      "division": "div1",
+      "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+      "lastSolve": 14000,
+      "lastTiebreakEligibleSolve": 14000,
+      "name": "a",
+      "score": 100,
+      "solvedChallengeIds": Array [
+        "3195c55f-377a-4c78-924e-820e48d7674d",
+      ],
+    },
+  ],
+  "leaderboardUpdate": 19000,
+}
+`;
+
+exports[`E2E snapshots ranking tiebreakEligible false no tiebreak: Mid CTF tie 1`] = `
+Object {
+  "challengeInfos": Map {
+    "3195c55f-377a-4c78-924e-820e48d7674d" => Object {
+      "id": "3195c55f-377a-4c78-924e-820e48d7674d",
+      "score": 100,
+      "solves": 2,
+      "tiebreakEligible": true,
+    },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 1,
+      "solves": 0,
+      "tiebreakEligible": false,
+    },
+  },
+  "graphLeaderboards": Array [
+    Object {
+      "sample": 10000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 11000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 12000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 13000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 14000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 15000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 16000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+    Object {
+      "sample": 17000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+  ],
+  "leaderboard": Array [
+    Object {
+      "division": "div1",
+      "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+      "lastSolve": 14000,
+      "lastTiebreakEligibleSolve": 14000,
+      "name": "a",
+      "score": 100,
+      "solvedChallengeIds": Array [
+        "3195c55f-377a-4c78-924e-820e48d7674d",
+      ],
+    },
+    Object {
+      "division": "div2",
+      "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+      "lastSolve": 16000,
+      "lastTiebreakEligibleSolve": 16000,
+      "name": "b",
+      "score": 100,
+      "solvedChallengeIds": Array [
+        "3195c55f-377a-4c78-924e-820e48d7674d",
+      ],
+    },
+  ],
+  "leaderboardUpdate": 17000,
+}
+`;
+
+exports[`E2E snapshots ranking tiebreakEligible false no tiebreak: Post CTF backfill 1`] = `
+Object {
+  "challengeInfos": Map {
+    "3195c55f-377a-4c78-924e-820e48d7674d" => Object {
+      "id": "3195c55f-377a-4c78-924e-820e48d7674d",
+      "score": 100,
+      "solves": 2,
+      "tiebreakEligible": true,
+    },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 1,
+      "solves": 2,
+      "tiebreakEligible": false,
+    },
+  },
+  "graphLeaderboards": Array [
+    Object {
+      "sample": 10000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 11000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 12000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 13000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 14000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 15000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 16000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+    Object {
+      "sample": 17000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+    Object {
+      "sample": 18000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 101,
+        },
+      ],
+    },
+    Object {
+      "sample": 19000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 101,
+        },
+      ],
+    },
+    Object {
+      "sample": 20000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 101,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 101,
+        },
+      ],
+    },
+  ],
+  "leaderboard": Array [
+    Object {
+      "division": "div1",
+      "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+      "lastSolve": 20000,
+      "lastTiebreakEligibleSolve": 14000,
+      "name": "a",
+      "score": 101,
+      "solvedChallengeIds": Array [
+        "3195c55f-377a-4c78-924e-820e48d7674d",
+        "134785d3-08e7-48c5-99c0-18b966172636",
+      ],
+    },
+    Object {
+      "division": "div2",
+      "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+      "lastSolve": 18000,
+      "lastTiebreakEligibleSolve": 16000,
+      "name": "b",
+      "score": 101,
+      "solvedChallengeIds": Array [
+        "3195c55f-377a-4c78-924e-820e48d7674d",
+        "134785d3-08e7-48c5-99c0-18b966172636",
+      ],
+    },
+  ],
+  "leaderboardUpdate": 20000,
+}
+`;
+
+exports[`E2E snapshots ranking tiebreakEligible false no tiebreak: Post CTF relative 1`] = `
+Object {
+  "challengeInfos": Map {
+    "3195c55f-377a-4c78-924e-820e48d7674d" => Object {
+      "id": "3195c55f-377a-4c78-924e-820e48d7674d",
+      "score": 100,
+      "solves": 2,
+      "tiebreakEligible": true,
+    },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 1,
+      "solves": 2,
+      "tiebreakEligible": false,
+    },
+  },
+  "graphLeaderboards": Array [
+    Object {
+      "sample": 20000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 101,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 101,
+        },
+      ],
+    },
+  ],
+  "leaderboard": Array [
+    Object {
+      "division": "div1",
+      "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+      "lastSolve": 20000,
+      "lastTiebreakEligibleSolve": 14000,
+      "name": "a",
+      "score": 101,
+      "solvedChallengeIds": Array [
+        "3195c55f-377a-4c78-924e-820e48d7674d",
+        "134785d3-08e7-48c5-99c0-18b966172636",
+      ],
+    },
+    Object {
+      "division": "div2",
+      "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+      "lastSolve": 18000,
+      "lastTiebreakEligibleSolve": 16000,
+      "name": "b",
+      "score": 101,
+      "solvedChallengeIds": Array [
+        "3195c55f-377a-4c78-924e-820e48d7674d",
+        "134785d3-08e7-48c5-99c0-18b966172636",
+      ],
+    },
+  ],
+  "leaderboardUpdate": 20000,
+}
+`;
+
+exports[`E2E snapshots ranking tiebreakEligible false no tiebreak: Pre CTF 1`] = `
+Object {
+  "challengeInfos": Map {
+    "3195c55f-377a-4c78-924e-820e48d7674d" => Object {
+      "id": "3195c55f-377a-4c78-924e-820e48d7674d",
+      "score": 500,
+      "solves": 0,
+      "tiebreakEligible": true,
+    },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 1,
+      "solves": 0,
+      "tiebreakEligible": false,
+    },
+  },
+  "graphLeaderboards": Array [],
+  "leaderboard": Array [],
+  "leaderboardUpdate": 5000,
+}
+`;
+
+exports[`E2E snapshots ranking tiebreakEligible false only team: Mid CTF 1`] = `
+Object {
+  "challengeInfos": Map {
+    "3195c55f-377a-4c78-924e-820e48d7674d" => Object {
+      "id": "3195c55f-377a-4c78-924e-820e48d7674d",
+      "score": 500,
+      "solves": 0,
+      "tiebreakEligible": true,
+    },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 100,
+      "solves": 1,
+      "tiebreakEligible": false,
+    },
+  },
+  "graphLeaderboards": Array [
+    Object {
+      "sample": 10000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 11000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 12000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 13000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 14000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+    Object {
+      "sample": 15000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+  ],
+  "leaderboard": Array [
+    Object {
+      "division": "div2",
+      "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+      "lastSolve": 14000,
+      "lastTiebreakEligibleSolve": undefined,
+      "name": "b",
+      "score": 100,
+      "solvedChallengeIds": Array [
+        "134785d3-08e7-48c5-99c0-18b966172636",
+      ],
+    },
+  ],
+  "leaderboardUpdate": 15000,
+}
+`;
+
+exports[`E2E snapshots ranking tiebreakEligible false only team: Post CTF backfill 1`] = `
+Object {
+  "challengeInfos": Map {
+    "3195c55f-377a-4c78-924e-820e48d7674d" => Object {
+      "id": "3195c55f-377a-4c78-924e-820e48d7674d",
+      "score": 100,
+      "solves": 1,
+      "tiebreakEligible": true,
+    },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 100,
+      "solves": 1,
+      "tiebreakEligible": false,
+    },
+  },
+  "graphLeaderboards": Array [
+    Object {
+      "sample": 10000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 11000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 12000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 13000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 14000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+    Object {
+      "sample": 15000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+    Object {
+      "sample": 16000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+    Object {
+      "sample": 17000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+    Object {
+      "sample": 18000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+    Object {
+      "sample": 19000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+    Object {
+      "sample": 20000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+  ],
+  "leaderboard": Array [
+    Object {
+      "division": "div1",
+      "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+      "lastSolve": 16000,
+      "lastTiebreakEligibleSolve": 16000,
+      "name": "a",
+      "score": 100,
+      "solvedChallengeIds": Array [
+        "3195c55f-377a-4c78-924e-820e48d7674d",
+      ],
+    },
+    Object {
+      "division": "div2",
+      "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+      "lastSolve": 14000,
+      "lastTiebreakEligibleSolve": undefined,
+      "name": "b",
+      "score": 100,
+      "solvedChallengeIds": Array [
+        "134785d3-08e7-48c5-99c0-18b966172636",
+      ],
+    },
+  ],
+  "leaderboardUpdate": 20000,
+}
+`;
+
+exports[`E2E snapshots ranking tiebreakEligible false only team: Post CTF relative 1`] = `
+Object {
+  "challengeInfos": Map {
+    "3195c55f-377a-4c78-924e-820e48d7674d" => Object {
+      "id": "3195c55f-377a-4c78-924e-820e48d7674d",
+      "score": 100,
+      "solves": 1,
+      "tiebreakEligible": true,
+    },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 100,
+      "solves": 1,
+      "tiebreakEligible": false,
+    },
+  },
+  "graphLeaderboards": Array [
+    Object {
+      "sample": 16000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+    Object {
+      "sample": 17000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+    Object {
+      "sample": 18000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+    Object {
+      "sample": 19000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+    Object {
+      "sample": 20000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 100,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 100,
+        },
+      ],
+    },
+  ],
+  "leaderboard": Array [
+    Object {
+      "division": "div1",
+      "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+      "lastSolve": 16000,
+      "lastTiebreakEligibleSolve": 16000,
+      "name": "a",
+      "score": 100,
+      "solvedChallengeIds": Array [
+        "3195c55f-377a-4c78-924e-820e48d7674d",
+      ],
+    },
+    Object {
+      "division": "div2",
+      "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+      "lastSolve": 14000,
+      "lastTiebreakEligibleSolve": undefined,
+      "name": "b",
+      "score": 100,
+      "solvedChallengeIds": Array [
+        "134785d3-08e7-48c5-99c0-18b966172636",
+      ],
+    },
+  ],
+  "leaderboardUpdate": 20000,
+}
+`;
+
+exports[`E2E snapshots ranking tiebreakEligible false only team: Pre CTF 1`] = `
+Object {
+  "challengeInfos": Map {
+    "3195c55f-377a-4c78-924e-820e48d7674d" => Object {
+      "id": "3195c55f-377a-4c78-924e-820e48d7674d",
+      "score": 500,
+      "solves": 0,
+      "tiebreakEligible": true,
+    },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 500,
+      "solves": 0,
+      "tiebreakEligible": false,
+    },
+  },
+  "graphLeaderboards": Array [],
+  "leaderboard": Array [],
+  "leaderboardUpdate": 5000,
+}
+`;
+
+exports[`E2E snapshots ranking tiebreakEligible false with tiebreak: Mid CTF no tie 1`] = `
+Object {
+  "challengeInfos": Map {
+    "3195c55f-377a-4c78-924e-820e48d7674d" => Object {
+      "id": "3195c55f-377a-4c78-924e-820e48d7674d",
+      "score": 500,
+      "solves": 0,
+      "tiebreakEligible": true,
+    },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 1,
+      "solves": 1,
+      "tiebreakEligible": false,
+    },
+  },
+  "graphLeaderboards": Array [
+    Object {
+      "sample": 10000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 11000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 12000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 13000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 14000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 1,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 15000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 1,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+  ],
+  "leaderboard": Array [
+    Object {
+      "division": "div1",
+      "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+      "lastSolve": 14000,
+      "lastTiebreakEligibleSolve": undefined,
+      "name": "a",
+      "score": 1,
+      "solvedChallengeIds": Array [
+        "134785d3-08e7-48c5-99c0-18b966172636",
+      ],
+    },
+  ],
+  "leaderboardUpdate": 15000,
+}
+`;
+
+exports[`E2E snapshots ranking tiebreakEligible false with tiebreak: Mid CTF tie 1`] = `
+Object {
+  "challengeInfos": Map {
+    "3195c55f-377a-4c78-924e-820e48d7674d" => Object {
+      "id": "3195c55f-377a-4c78-924e-820e48d7674d",
+      "score": 500,
+      "solves": 0,
+      "tiebreakEligible": true,
+    },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 1,
+      "solves": 2,
+      "tiebreakEligible": false,
+    },
+  },
+  "graphLeaderboards": Array [
+    Object {
+      "sample": 10000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 11000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 12000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 13000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 14000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 1,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 15000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 1,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 16000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 1,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 1,
+        },
+      ],
+    },
+    Object {
+      "sample": 17000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 1,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 1,
+        },
+      ],
+    },
+  ],
+  "leaderboard": Array [
+    Object {
+      "division": "div1",
+      "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+      "lastSolve": 14000,
+      "lastTiebreakEligibleSolve": undefined,
+      "name": "a",
+      "score": 1,
+      "solvedChallengeIds": Array [
+        "134785d3-08e7-48c5-99c0-18b966172636",
+      ],
+    },
+    Object {
+      "division": "div2",
+      "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+      "lastSolve": 16000,
+      "lastTiebreakEligibleSolve": undefined,
+      "name": "b",
+      "score": 1,
+      "solvedChallengeIds": Array [
+        "134785d3-08e7-48c5-99c0-18b966172636",
+      ],
+    },
+  ],
+  "leaderboardUpdate": 17000,
+}
+`;
+
+exports[`E2E snapshots ranking tiebreakEligible false with tiebreak: Post CTF backfill 1`] = `
+Object {
+  "challengeInfos": Map {
+    "3195c55f-377a-4c78-924e-820e48d7674d" => Object {
+      "id": "3195c55f-377a-4c78-924e-820e48d7674d",
+      "score": 213,
+      "solves": 1,
+      "tiebreakEligible": true,
+    },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 1,
+      "solves": 2,
+      "tiebreakEligible": false,
+    },
+  },
+  "graphLeaderboards": Array [
+    Object {
+      "sample": 10000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 11000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 12000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 13000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 0,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 14000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 1,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 15000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 1,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 0,
+        },
+      ],
+    },
+    Object {
+      "sample": 16000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 1,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 1,
+        },
+      ],
+    },
+    Object {
+      "sample": 17000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 1,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 1,
+        },
+      ],
+    },
+    Object {
+      "sample": 18000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 1,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 214,
+        },
+      ],
+    },
+    Object {
+      "sample": 19000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 1,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 214,
+        },
+      ],
+    },
+    Object {
+      "sample": 20000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 1,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 214,
+        },
+      ],
+    },
+  ],
+  "leaderboard": Array [
+    Object {
+      "division": "div2",
+      "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+      "lastSolve": 18000,
+      "lastTiebreakEligibleSolve": 18000,
+      "name": "b",
+      "score": 214,
+      "solvedChallengeIds": Array [
+        "134785d3-08e7-48c5-99c0-18b966172636",
+        "3195c55f-377a-4c78-924e-820e48d7674d",
+      ],
+    },
+    Object {
+      "division": "div1",
+      "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+      "lastSolve": 14000,
+      "lastTiebreakEligibleSolve": undefined,
+      "name": "a",
+      "score": 1,
+      "solvedChallengeIds": Array [
+        "134785d3-08e7-48c5-99c0-18b966172636",
+      ],
+    },
+  ],
+  "leaderboardUpdate": 20000,
+}
+`;
+
+exports[`E2E snapshots ranking tiebreakEligible false with tiebreak: Post CTF relative 1`] = `
+Object {
+  "challengeInfos": Map {
+    "3195c55f-377a-4c78-924e-820e48d7674d" => Object {
+      "id": "3195c55f-377a-4c78-924e-820e48d7674d",
+      "score": 213,
+      "solves": 1,
+      "tiebreakEligible": true,
+    },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 1,
+      "solves": 2,
+      "tiebreakEligible": false,
+    },
+  },
+  "graphLeaderboards": Array [
+    Object {
+      "sample": 18000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 1,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 214,
+        },
+      ],
+    },
+    Object {
+      "sample": 19000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 1,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 214,
+        },
+      ],
+    },
+    Object {
+      "sample": 20000,
+      "userInfos": Array [
+        Object {
+          "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+          "score": 1,
+        },
+        Object {
+          "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+          "score": 214,
+        },
+      ],
+    },
+  ],
+  "leaderboard": Array [
+    Object {
+      "division": "div2",
+      "id": "86583c14-a264-4bc1-8a0d-94f462e0f7d3",
+      "lastSolve": 18000,
+      "lastTiebreakEligibleSolve": 18000,
+      "name": "b",
+      "score": 214,
+      "solvedChallengeIds": Array [
+        "134785d3-08e7-48c5-99c0-18b966172636",
+        "3195c55f-377a-4c78-924e-820e48d7674d",
+      ],
+    },
+    Object {
+      "division": "div1",
+      "id": "225cd1ef-9ad3-4039-97eb-81a113189b9c",
+      "lastSolve": 14000,
+      "lastTiebreakEligibleSolve": undefined,
+      "name": "a",
+      "score": 1,
+      "solvedChallengeIds": Array [
+        "134785d3-08e7-48c5-99c0-18b966172636",
+      ],
+    },
+  ],
+  "leaderboardUpdate": 20000,
+}
+`;
+
+exports[`E2E snapshots ranking tiebreakEligible false with tiebreak: Pre CTF 1`] = `
+Object {
+  "challengeInfos": Map {
+    "3195c55f-377a-4c78-924e-820e48d7674d" => Object {
+      "id": "3195c55f-377a-4c78-924e-820e48d7674d",
+      "score": 500,
+      "solves": 0,
+      "tiebreakEligible": true,
+    },
+    "134785d3-08e7-48c5-99c0-18b966172636" => Object {
+      "id": "134785d3-08e7-48c5-99c0-18b966172636",
+      "score": 1,
+      "solves": 0,
+      "tiebreakEligible": false,
+    },
+  },
+  "graphLeaderboards": Array [],
+  "leaderboard": Array [],
+  "leaderboardUpdate": 5000,
 }
 `;

--- a/packages/server/test/unit/leaderboard/calculate.ts
+++ b/packages/server/test/unit/leaderboard/calculate.ts
@@ -97,6 +97,20 @@ describe('E2E snapshots', () => {
         max: 500,
       },
     },
+    {
+      id: '134785d3-08e7-48c5-99c0-18b966172636',
+      name: 'chall2',
+      description: '',
+      category: 'cat1',
+      author: '',
+      files: [],
+      flag: 'flag2',
+      tiebreakEligible: false,
+      points: {
+        min: 1,
+        max: 1,
+      },
+    },
   ]
 
   test('coherent data', () => {
@@ -148,5 +162,133 @@ describe('E2E snapshots', () => {
     }
 
     expect(doCalculate(fullData, 25000)).toMatchSnapshot('Post CTF')
+  })
+
+  test('ranking tiebreakEligible false no tiebreak', () => {
+    const fullData: WorkerRequest = {
+      users,
+      challenges,
+      solves: [
+        {
+          id: '2f436f67-f1b5-4802-8a55-c66081055942',
+          challengeid: challenges[0].id,
+          userid: users[0].id,
+          createdat: new Date(14000),
+        },
+        {
+          id: '13975f87-9401-4d98-90e7-492579e5d7dc',
+          challengeid: challenges[0].id,
+          userid: users[1].id,
+          createdat: new Date(16000),
+        },
+        {
+          id: '0ba0ffe3-2809-4a9f-be09-6295e9a11a38',
+          challengeid: challenges[1].id,
+          userid: users[1].id,
+          createdat: new Date(18000),
+        },
+        {
+          id: '003033f5-28e1-4013-a7e5-876e6decd0e7',
+          challengeid: challenges[1].id,
+          userid: users[0].id,
+          createdat: new Date(20000),
+        },
+      ],
+      graphUpdate: 0,
+      config,
+    }
+
+    expect(doCalculate(fullData, 5000)).toMatchSnapshot('Pre CTF')
+    expect(doCalculate(fullData, 15000)).toMatchSnapshot('Mid CTF no tie')
+    expect(doCalculate(fullData, 17000)).toMatchSnapshot('Mid CTF tie')
+    expect(doCalculate(fullData, 19000)).toMatchSnapshot('Mid CTF one tiebreak')
+    expect(doCalculate(fullData, 25000, true)).toMatchSnapshot(
+      'Post CTF relative'
+    )
+    expect(doCalculate(fullData, 25000, false)).toMatchSnapshot(
+      'Post CTF backfill'
+    )
+  })
+
+  test('ranking tiebreakEligible false with tiebreak', () => {
+    const fullData: WorkerRequest = {
+      users,
+      challenges,
+      solves: [
+        {
+          id: '2f436f67-f1b5-4802-8a55-c66081055942',
+          challengeid: challenges[1].id,
+          userid: users[0].id,
+          createdat: new Date(14000),
+        },
+        {
+          id: '13975f87-9401-4d98-90e7-492579e5d7dc',
+          challengeid: challenges[1].id,
+          userid: users[1].id,
+          createdat: new Date(16000),
+        },
+        {
+          id: '0ba0ffe3-2809-4a9f-be09-6295e9a11a38',
+          challengeid: challenges[0].id,
+          userid: users[1].id,
+          createdat: new Date(18000),
+        },
+      ],
+      graphUpdate: 0,
+      config,
+    }
+
+    expect(doCalculate(fullData, 5000)).toMatchSnapshot('Pre CTF')
+    expect(doCalculate(fullData, 15000)).toMatchSnapshot('Mid CTF no tie')
+    expect(doCalculate(fullData, 17000)).toMatchSnapshot('Mid CTF tie')
+    expect(doCalculate(fullData, 25000, true)).toMatchSnapshot(
+      'Post CTF relative'
+    )
+    expect(doCalculate(fullData, 25000, false)).toMatchSnapshot(
+      'Post CTF backfill'
+    )
+  })
+
+  test('ranking tiebreakEligible false only team', () => {
+    const fullData: WorkerRequest = {
+      users,
+      challenges: [
+        challenges[0],
+        {
+          ...challenges[1],
+          // force points to match other challenge to cause tiebreak
+          // resolution to occur
+          points: {
+            min: 100,
+            max: 500,
+          },
+        },
+      ],
+      solves: [
+        {
+          id: '13975f87-9401-4d98-90e7-492579e5d7dc',
+          challengeid: challenges[1].id,
+          userid: users[1].id,
+          createdat: new Date(14000),
+        },
+        {
+          id: '2f436f67-f1b5-4802-8a55-c66081055942',
+          challengeid: challenges[0].id,
+          userid: users[0].id,
+          createdat: new Date(16000),
+        },
+      ],
+      graphUpdate: 0,
+      config,
+    }
+
+    expect(doCalculate(fullData, 5000)).toMatchSnapshot('Pre CTF')
+    expect(doCalculate(fullData, 15000)).toMatchSnapshot('Mid CTF')
+    expect(doCalculate(fullData, 25000, true)).toMatchSnapshot(
+      'Post CTF relative'
+    )
+    expect(doCalculate(fullData, 25000, false)).toMatchSnapshot(
+      'Post CTF backfill'
+    )
   })
 })


### PR DESCRIPTION
Backports changes from #543

Also adjusted types at the module boundary of the leaderboard worker code to hide implementation detail data.
This change also strips the data from the objects, resulting in the creation of a new JS object per leaderboard entry, but keeps snapshots cleaner. We may wish to consider doing this in only snapshot serialization in the future.
