### PR TITLE
Fix typo in GCS docs

### DIFF
--- a/docs/content/providers/uploads/gcs.md
+++ b/docs/content/providers/uploads/gcs.md
@@ -10,7 +10,7 @@ Option|Description
 -|-
 `credentials.private_key`|The PEM-encoded private key for the service account with access to the GCS bucket.
 `credentials.client_email`|The email of the service account with access to the GCS bucket.
-`bucket`|The name of the GCS bucket.
+`bucketName`|The name of the GCS bucket.
 
 ## Configuration Example
 


### PR DESCRIPTION
https://github.com/redpwn/rctf/blob/0f05c62e45c565fa4873e264656dd74d4e3ec833/server/providers/uploads/gcs/index.ts#L17