### PR TITLE
fix(server): file persistence for local upload provider

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - PORT=80
     volumes:
       - ./conf.d:/app/conf.d
+      - ./data/rctf-uploads:/app/uploads
     depends_on:
       - redis
       - postgres

--- a/install/install.sh
+++ b/install/install.sh
@@ -69,7 +69,7 @@ do_install() {
 
   RCTF_GIT_REF="${RCTF_GIT_REF:-"master"}"
 
-  mkdir -p conf.d data/rctf-postgres data/rctf-redis
+  mkdir -p conf.d data/rctf-postgres data/rctf-redis data/rctf-uploads
 
   printf "%s\n" \
   "RCTF_DATABASE_PASSWORD=$(get_key)" \


### PR DESCRIPTION
Fix:
- create a `data/rctf-uploads` folder in the install script
- in the docker-compose file, create a docker bind mount from the `data/rctf-uploads` folder to `/app/uploads` in the rctf
- in the local upload provider, save and load `uploadMap` from the `uploadMap.json` file