### PR TITLE
Updating install.sh to use `docker compose` instead of deprecated `docker-compose`

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -45,7 +45,7 @@ do_install() {
   if [ -d "$RCTF_INSTALL_PATH" ]; then
     error "rCTF appears to already be installed in ${RCTF_INSTALL_PATH}"
 
-    info "... If you're trying to start rCTF, run 'docker-compose up -d'."
+    info "... If you're trying to start rCTF, run 'docker compose up -d'."
     info "... If you're trying to reinstall rCTF, 'rm -rf $RCTF_INSTALL_PATH' then re-run this script."
 
     exit 1
@@ -58,11 +58,6 @@ do_install() {
 
   if [ ! -x "$(command -v docker)" ]; then
     curl -fsS https://get.docker.com | sh
-  fi
-
-  if [ ! -x "$(command -v docker-compose)" ]; then
-    curl -fsSLo /usr/local/bin/docker-compose "https://github.com/docker/compose/releases/download/1.26.2/docker-compose-$(uname -s)-$(uname -m)"
-    chmod +x /usr/local/bin/docker-compose
   fi
 
   info "Configuring rCTF..."
@@ -108,7 +103,7 @@ do_install() {
   info "Downloading rCTF..."
 
   curl -fsSO "https://raw.githubusercontent.com/redpwn/rctf/$RCTF_GIT_REF/docker-compose.yml"
-  docker-compose pull
+  docker compose pull
 
   info "Finished installation to ${RCTF_INSTALL_PATH}."
 
@@ -117,12 +112,12 @@ do_install() {
   read -r result </dev/tty
 
   if [ "$result" = "y" ]; then
-    info "Running 'docker-compose up -d'..."
-    docker-compose up -d
+    info "Running 'docker compose up -d'..."
+    docker compose up -d
     info "rCTF is now running at 127.0.0.1:8080."
     exit 0
   else
-    info "If you would like to start rCTF, run 'docker-compose up -d' in $RCTF_INSTALL_PATH."
+    info "If you would like to start rCTF, run 'docker compose up -d' in $RCTF_INSTALL_PATH."
     exit 0
   fi
 }


### PR DESCRIPTION
The install method provided by install.sh will also already handle installing the latest version of `docker compose` when pulling from get.docker.com